### PR TITLE
Improve fallback TTS support

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ progress::-webkit-progress-value{background:#0f0}
        data-ad-client="ca-pub-4003447295960802" data-ad-slot="YOUR_AD_SLOT"></ins>
   <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
 </div>
-
+<script src="https://unpkg.com/mespeak/mespeak.min.js"></script>
 <script>
 /* ==========  CONSTANTS  ========== */
 const CHUNK   = 900;          // 900 chars per utterance
@@ -68,6 +68,10 @@ const txt   = $('txt'), langSel=$('lang'), voiceSel=$('voice'),
       bar   = $('bar'), ela=$('ela'), rem=$('rem'), pct=$('meter').firstElementChild,
       startB=$('start'), pauseB=$('pause'), resumeB=$('resume'), stopB=$('stop'),
       disp  = $('disp');
+
+window.mespeakLoaded=false;
+mespeak.loadConfig("https://unpkg.com/mespeak/mespeak_config.json");
+mespeak.loadVoice("https://unpkg.com/mespeak/voices/en/en.json",()=>{window.mespeakLoaded=true;});
 
 /* ==========  GLOBALS  ========== */
 let voices       = [];
@@ -217,6 +221,17 @@ function highlight(charIdx){
 
 /* ==========  FALLBACK (VoiceRSS)  ========== */
 async function fallbackSpeak(){
+  if(window.mespeakLoaded){
+    progChar=0; startTime=Date.now(); isSpeaking=true;
+    const chunks = txt.value.match(new RegExp(`[\s\S]{1,${CHUNK}}(?:\s|$)`,'g'))||[];
+    for(const chunk of chunks){
+      await playViaMeSpeak(chunk);
+      progChar+=chunk.length;
+      updateMeter(progChar);
+    }
+    finish();
+    return;
+  }
   if(!keyRSS){alert('No local voices & no VoiceRSS key');return;}
   progChar=0; startTime=Date.now(); isSpeaking=true;
   const chunks = txt.value.match(new RegExp(`[\\s\\S]{1,${CHUNK}}(?:\\s|$)`,'g'))||[];
@@ -235,6 +250,15 @@ function playViaRSS(textPart){
     const tID=setInterval(()=>updateMeter(base+Math.round(len*(aud.currentTime/aud.duration||0))),200);
     aud.onended=()=>{clearInterval(tID); res();};
     document.addEventListener('visibilitychange',()=>{if(!document.hidden) aud.play();});
+  });
+}
+
+function playViaMeSpeak(textPart){
+  return new Promise(res=>{
+    mespeak.speak(textPart,{
+      speed:+rateR.value*175,
+      amplitude:100
+    },res);
   });
 }
 

--- a/texttospeech.html
+++ b/texttospeech.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Text-to-Speech Website</title>
     <link rel="stylesheet" href="styles.css">
+<script src="https://unpkg.com/mespeak/mespeak.min.js"></script>
 </head>
 <body>
     <h1>Text-to-Speech Reader</h1>
@@ -56,6 +57,10 @@
         let previousText = "";
         let readingStartTime = null;
         let cachedSpans = null; // Cache spans for performance optimization
+
+window.mespeakLoaded=false;
+mespeak.loadConfig("https://unpkg.com/mespeak/mespeak_config.json");
+mespeak.loadVoice("https://unpkg.com/mespeak/voices/en/en.json",()=>{window.mespeakLoaded=true;});
 
         const textDisplay = document.getElementById('textDisplay');
         const textInput = document.getElementById('textInput');
@@ -179,6 +184,11 @@
 
             if (!text) {
                 alert('Please enter some text to read aloud.');
+                return;
+            }
+
+            if(voices.length===0 || voicesDropdown.value==='-1'){
+                mespeak.speak(text,{speed:parseFloat(rateControl.value)*175});
                 return;
             }
 


### PR DESCRIPTION
## Summary
- add mespeak JS library as a CDN script
- initialise mespeak and load an English voice
- extend fallback speech routine to use mespeak before VoiceRSS
- simple mespeak support in the texttospeech demo

## Testing
- `node --version`
- `python3 --version`


------
https://chatgpt.com/codex/tasks/task_e_687b0e3e420c8331afa7d03f2444416d