### PR TITLE
Add benefits page for internal link

### DIFF
--- a/benefits.html
+++ b/benefits.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Benefits | Read-Aloud</title>
+  <meta name="description" content="Discover the key benefits of using our free text-to-speech reader, including accessibility, productivity, and learning enhancements.">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <!-- HEADER -->
+  <header>
+      <nav aria-label="Primary">
+        <a href="index.html">Home</a>
+        <a href="voices.html">Voices</a>
+        <a href="help.html">Help</a>
+        <a href="guides.html">Guides</a>
+        <a href="about.html">About</a>
+        <a href="privacy.html">Privacy</a>
+      </nav>
+    </header>
+
+  <!-- MAIN CONTENT: Benefits Section -->
+  <main>
+    <section id="benefits">
+      <div class="container">
+        <h2>Why Use Our Tool?</h2>
+        <div class="benefit">
+          <h3>Accessibility</h3>
+          <p>Listen to text if you have visual impairments or dyslexia. Our tool aims to break down barriers by providing voice options in multiple languages.</p>
+        </div>
+        <div class="benefit">
+          <h3>Productivity</h3>
+          <p>Convert emails, articles, and reports to audio on the go. Stay efficient by “reading” even when your eyes are busy.</p>
+        </div>
+        <div class="benefit">
+          <h3>Learning</h3>
+          <p>Enhance your studies by listening to your notes or foreign language texts. Hearing text can improve comprehension and retention.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- FOOTER -->
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 Read-Aloud.com. All rights reserved.</p>
+        <nav>
+          <ul>
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a benefits.html page so internal links resolve to a live benefits/use-cases page
- align footer links on the benefits page to the existing privacy, terms, and contact HTML files
- verified no internal HTML links point to missing files across the site

## Testing
- python - <<'PY'
import os
root='.'
html_files=[]
for dirpath, dirs, files in os.walk(root):
    for f in files:
        if f.endswith('.html'):
            html_files.append(os.path.relpath(os.path.join(dirpath,f), root))

def norm(p):
    p=p.lstrip('./')
    if p.startswith('/'):
        p=p[1:]
    return p
existing=set(map(norm, html_files))
from html.parser import HTMLParser
class P(HTMLParser):
    def __init__(self):
        super().__init__();self.links=[]
    def handle_starttag(self, tag, attrs):
        if tag=='a':
            href=dict(attrs).get('href')
            if href:
                self.links.append(href)
link_sources={}
for file in html_files:
    parser=P()
    with open(file,encoding='utf-8') as f:
        parser.feed(f.read())
    for href in parser.links:
        if href.endswith('.html') and not href.startswith('http') and not href.startswith('mailto:'):
            link_sources.setdefault(href, []).append(file)

broken={}
for href, srcs in link_sources.items():
    if norm(href) not in existing:
        broken[href]=srcs
print('Broken', len(broken))
if broken:
    for href, srcs in broken.items():
        print(href, '->', srcs)
else:
    print('No broken internal HTML links.')
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ecb3330a88331bee76492b8b911e7)