### PR TITLE
Add Amazon associate disclosure to site footers

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,6 +10,7 @@
   header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
   header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
   header a:hover,footer a:hover{text-decoration:underline}
+  footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
   main{max-width:980px;margin:auto;padding:24px}
   h1{margin-top:0}
   .small{color:#444;font-size:0.95em}
@@ -122,6 +123,7 @@
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -9,6 +9,7 @@
 body{margin:0;font:16px/1.6 Arial,Helvetica,sans-serif;background:#fff;color:#111}
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:720px;margin:auto;padding:26px}
 label{display:block;margin:12px 0 4px}
 input,textarea{width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;font-size:15px;box-sizing:border-box}
@@ -52,6 +53,7 @@ button{margin-top:12px;padding:10px 18px;background:#ff0;border:2px solid #777;f
 
 <footer>
   © 2025 Read-Aloud
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/guide-browser-compatibility.html
+++ b/guide-browser-compatibility.html
@@ -10,6 +10,7 @@ body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#1
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
 header a:hover,footer a:hover{text-decoration:underline}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:980px;margin:auto;padding:24px}
 h1{margin-top:0}
 .small{color:#444;font-size:0.95em}
@@ -169,6 +170,7 @@ hr{margin:24px 0}
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/guide-dyslexia-adhd.html
+++ b/guide-dyslexia-adhd.html
@@ -10,6 +10,7 @@ body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#1
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
 header a:hover,footer a:hover{text-decoration:underline}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:900px;margin:auto;padding:24px}
 h1{margin-top:0}
 .box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
@@ -125,6 +126,7 @@ hr{margin:24px 0}
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/guide-how-to-use.html
+++ b/guide-how-to-use.html
@@ -10,6 +10,7 @@ body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#1
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
 header a:hover,footer a:hover{text-decoration:underline}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:900px;margin:auto;padding:24px}
 h1{margin-top:0}
 .small{color:#444;font-size:0.95em}
@@ -110,6 +111,7 @@ Question: does it pause correctly after commas, periods, and question marks?</pr
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/guide-language-learning.html
+++ b/guide-language-learning.html
@@ -10,6 +10,7 @@ body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#1
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
 header a:hover,footer a:hover{text-decoration:underline}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:900px;margin:auto;padding:24px}
 h1{margin-top:0}
 .tip{background:#eef7ff;border:1px solid #b8d8ff;padding:12px;border-radius:10px}
@@ -142,6 +143,7 @@ FRANÇAIS (French)
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/guide-mp3-export.html
+++ b/guide-mp3-export.html
@@ -10,6 +10,7 @@
   header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
   header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
   header a:hover,footer a:hover{text-decoration:underline}
+  footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
   main{max-width:980px;margin:auto;padding:24px}
   h1{margin-top:0}
   .small{color:#444;font-size:0.95em}
@@ -136,6 +137,7 @@
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/guide-privacy.html
+++ b/guide-privacy.html
@@ -10,6 +10,7 @@ body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#1
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
 header a:hover,footer a:hover{text-decoration:underline}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:900px;margin:auto;padding:24px}
 h1{margin-top:0}
 .box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
@@ -115,6 +116,7 @@ hr{margin:24px 0}
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/guide-proofread.html
+++ b/guide-proofread.html
@@ -10,6 +10,7 @@ body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#1
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
 header a:hover,footer a:hover{text-decoration:underline}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:900px;margin:auto;padding:24px}
 h1{margin-top:0}
 .box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
@@ -140,6 +141,7 @@ hr{margin:24px 0}
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/guide-study.html
+++ b/guide-study.html
@@ -10,6 +10,7 @@ body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#1
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
 header a:hover,footer a:hover{text-decoration:underline}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:900px;margin:auto;padding:24px}
 h1{margin-top:0}
 .callout{background:#eef7ff;border:1px solid #b8d8ff;padding:12px;border-radius:10px}
@@ -155,6 +156,7 @@ Next step (choose one):
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/guides.html
+++ b/guides.html
@@ -10,6 +10,7 @@ body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#1
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
 header a:hover,footer a:hover{text-decoration:underline}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:900px;margin:auto;padding:24px}
 h1{margin-top:0}
 .small{color:#444;font-size:0.95em}
@@ -92,6 +93,7 @@ hr{margin:24px 0}
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/help.html
+++ b/help.html
@@ -9,6 +9,7 @@
 body{margin:0;font:16px/1.6 Arial,Helvetica,sans-serif;background:#fff;color:#111}
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:900px;margin:auto;padding:24px}
 h1{margin-top:0;font-size:1.9em}
 h2{margin-top:1.6em}
@@ -77,6 +78,7 @@ dl dt{font-weight:700;margin-top:12px}
 
 <footer>
   © 2025 Read-Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@ progress::-webkit-progress-value{background:#0f0}
 footer{background:#002060;color:#fff;padding:8px 0;text-align:center;font:14px Verdana}
 footer a{color:#fff;text-decoration:none;margin:0 6px}
 footer a:hover{text-decoration:underline}
+footer .small{display:block;font-size:12px;color:#e0e0ff;margin-top:4px}
 </style>
 
 <!-- Google AdSense -->
@@ -274,6 +275,7 @@ function updateBar(visits){
   <a href="https://coff.ee/readaloud" target="_blank" rel="noopener">Buy me a coffee</a> ·
   <a href="privacy.html">Privacy</a> ·
   <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -9,6 +9,7 @@
 body{margin:0;font:15px/1.6 Arial,Helvetica,sans-serif;background:#fff;color:#111}
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:840px;margin:auto;padding:24px}
 h1{margin-top:0}
 </style>
@@ -60,6 +61,7 @@ h1{margin-top:0}
 
 <footer>
   © 2025 Read-Aloud · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -9,6 +9,7 @@
 body{margin:0;font:15px/1.6 Arial,Helvetica,sans-serif;background:#fff;color:#111}
 header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
+footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
 main{max-width:840px;margin:auto;padding:24px}
 h1{margin-top:0}
 ol{padding-left:20px}
@@ -57,6 +58,7 @@ ol{padding-left:20px}
 
 <footer>
   © 2025 Read-Aloud
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Amazon Associate disclosure text to footers across core site pages
- style the disclosure for readability without cluttering the existing layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ecdd4feac833185520cd66a7f96d5)