### PR TITLE
Add Amazon Associates disclosure across site

### DIFF
--- a/Uses/proofreading.html
+++ b/Uses/proofreading.html
@@ -13,6 +13,7 @@ main{max-width:940px;margin:auto;padding:24px}
 h1{margin-top:0;font-size:1.9em}
 .tip{background:#fff;border-left:5px solid #004080;margin:20px 0;padding:14px}
 .ads{margin:36px auto;text-align:center}
+.small{font-size:0.9em;color:#e0e0e0}
 </style>
 </head>
 
@@ -74,9 +75,10 @@ h1{margin-top:0;font-size:1.9em}
 </main>
 
 <footer>
-  © 2025 Read-Aloud · 
-  <a href="../privacy.html">Privacy</a> · 
+  © 2025 Read-Aloud ·
+  <a href="../privacy.html">Privacy</a> ·
   <a href="../terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/Uses/study.html
+++ b/Uses/study.html
@@ -14,6 +14,7 @@ h1{margin-top:0;font-size:1.9em}
 section{margin-bottom:32px}
 .number{background:#004080;color:#fff;border-radius:50%;padding:4px 10px;margin-right:6px}
 .ads{margin:36px 0;text-align:center}
+.small{font-size:0.9em;color:#e0e0e0}
 </style>
 </head>
 
@@ -94,9 +95,10 @@ section{margin-bottom:32px}
 </main>
 
 <footer>
-  © 2025 Read-Aloud · 
-  <a href="../privacy.html">Privacy</a> · 
+  © 2025 Read-Aloud ·
+  <a href="../privacy.html">Privacy</a> ·
   <a href="../contact.html">Contact</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/audio.html
+++ b/audio.html
@@ -19,5 +19,9 @@
 
   <!-- Link to go back to your homepage -->
   <p><a href="index.html">Back to Home</a></p>
+
+  <footer style="margin-top:24px; text-align:center; font-size:0.9em; color:#444;">
+    As an Amazon Associate I earn from qualifying purchases.
+  </footer>
 </body>
 </html>

--- a/benefits.html
+++ b/benefits.html
@@ -52,6 +52,7 @@
             <li><a href="contact.html">Contact</a></li>
           </ul>
         </nav>
+      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
     </div>
   </footer>
 </body>

--- a/benifits.html
+++ b/benifits.html
@@ -52,6 +52,7 @@
           <li><a href="/contact">Contact</a></li>
         </ul>
       </nav>
+      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
     </div>
   </footer>
 </body>

--- a/blog.html
+++ b/blog.html
@@ -60,6 +60,7 @@
           <li><a href="/contact">Contact</a></li>
         </ul>
       </nav>
+      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
     </div>
   </footer>
 </body>

--- a/bookmark.html
+++ b/bookmark.html
@@ -131,6 +131,11 @@
                 gap: 10px;
             }
         }
+
+        .small {
+            font-size: 0.9em;
+            color: #444;
+        }
     </style>
 </head>
 <body>
@@ -361,5 +366,9 @@
         populateVoices();
 
     </script>
+
+    <footer style="margin-top:24px; text-align:center;">
+        <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+    </footer>
 </body>
 </html>

--- a/download-mp3.html
+++ b/download-mp3.html
@@ -26,6 +26,7 @@
     .status { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 13px; opacity: .9; white-space: pre-wrap; }
     footer { margin-top: 18px; opacity: .8; font-size: 14px; }
     .fineprint { font-size: 14px; opacity: .9; }
+    .small { font-size: 14px; opacity: .9; }
     .audio-wrap { margin-top: 10px; }
     audio { width: 100%; }
   </style>
@@ -128,6 +129,7 @@
 
   <footer>
     © 2025 Read‑Aloud · <a href="/terms.html">Terms</a>
+    <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
   </footer>
 
 <script>

--- a/faq.html
+++ b/faq.html
@@ -82,6 +82,7 @@
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/guides-how-to-use.html
+++ b/guides-how-to-use.html
@@ -126,6 +126,7 @@ hr{margin:24px 0}
 
 <footer>
   © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -46,6 +46,7 @@
           <li><a href="/contact">Contact</a></li>
         </ul>
       </nav>
+      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
     </div>
   </footer>
 </body>

--- a/read-aloud-premium/public/premium.html
+++ b/read-aloud-premium/public/premium.html
@@ -45,7 +45,11 @@
       <button id="generate">Generate MP3</button>
       <div id="download" style="margin-top: 16px;"></div>
     </main>
-    
+
+    <footer class="wrap">
+      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+    </footer>
+
     <script>window.API_BASE = 'https://api.read-aloud.com';</script>
 <script src="premium.js"></script>
   </body>

--- a/read-aloud-premium/public/voices.css
+++ b/read-aloud-premium/public/voices.css
@@ -51,3 +51,9 @@ body {
 .player {
   margin-top: 20px;
 }
+
+.small {
+  font-size: 14px;
+  color: #555;
+  margin-top: 12px;
+}

--- a/read-aloud-premium/public/voices.html
+++ b/read-aloud-premium/public/voices.html
@@ -19,9 +19,12 @@
         <audio id="audio" controls preload="none"></audio>
       </div>
     </main>
+    <footer class="wrap">
+      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+    </footer>
 <script>window.API_BASE = 'https://api.read-aloud.com';</script>
 
     <script src="voices.js"></script>
-  
+
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,11 @@ body {
     color: #333;
 }
 
+.small {
+    font-size: 0.9em;
+    color: #444;
+}
+
 /* Container for centering content where needed */
 .container {
     width: 90%;

--- a/support.html
+++ b/support.html
@@ -3,7 +3,11 @@
 <head>
 <meta charset="utf-8"><title>Contact | Read-Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<style>body{font-family:Arial,sans-serif;margin:2rem}form{max-width:500px}</style>
+<style>
+body{font-family:Arial,sans-serif;margin:2rem}
+form{max-width:500px}
+.small{font-size:0.9em;color:#444;margin-top:16px}
+</style>
 </head><body>
 <h1>Contact Us</h1>
 <form action="https://formspree.io/f/yourFormID" method="POST">
@@ -13,4 +17,7 @@
 <button type="submit">Send</button>
 </form>
 <p>Email: support@read-aloud.com</p>
+<footer>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+</footer>
 </body></html>

--- a/texttospeech.html
+++ b/texttospeech.html
@@ -289,5 +289,9 @@ mespeak.loadVoice("https://unpkg.com/mespeak/voices/en/en.json",()=>{window.mesp
         populateVoices();
 
     </script>
+
+    <footer style="margin-top:24px; text-align:center;">
+        <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+    </footer>
 </body>
 </html>

--- a/voices.html
+++ b/voices.html
@@ -11,6 +11,7 @@ header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
 header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
 main{max-width:900px;margin:auto;padding:20px}
 h1{margin-top:0;text-align:center}
+.small{font-size:0.9em;color:#e0e0e0}
 .grid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
 .voice card{background:#fff;border:1px solid #ddd;border-radius:6px;padding:12px}
 button.demo{width:100%;padding:10px;background:#ff0;border:2px solid #777;cursor:pointer;font:15px/1.2 Tahoma;color:#000}
@@ -58,9 +59,10 @@ button.demo{width:100%;padding:10px;background:#ff0;border:2px solid #777;cursor
 </main>
 
 <footer>
-  © 2025 Read-Aloud · 
-  <a href="contact.html">Contact</a> · 
+  © 2025 Read-Aloud ·
+  <a href="contact.html">Contact</a> ·
   <a href="terms.html">Terms</a>
+  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 
 <script>


### PR DESCRIPTION
## Summary
- add the required Amazon Associates disclosure to footers across core, guide, premium, and use-case pages
- add a reusable small-text style for consistent disclosure formatting

## Testing
- not run (static HTML changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ed04ff6688331be053d97e2e7d2bf)