### PR TITLE
Standardize navigation and footer

### DIFF
--- a/Uses/proofreading.html
+++ b/Uses/proofreading.html
@@ -19,11 +19,15 @@ h1{margin-top:0;font-size:1.9em}
 
 <body>
 <header>
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../help.html">Help</a>
-    <a href="../about.html">About</a>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
   </nav>
 </header>
 
@@ -75,10 +79,8 @@ h1{margin-top:0;font-size:1.9em}
 </main>
 
 <footer>
-  © 2025 Read-Aloud ·
-  <a href="../privacy.html">Privacy</a> ·
-  <a href="../terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/Uses/study.html
+++ b/Uses/study.html
@@ -20,11 +20,15 @@ section{margin-bottom:32px}
 
 <body>
 <header>
-  <nav>
-    <a href="../index.html">Home</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../help.html">Help</a>
-    <a href="../about.html">About</a>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
   </nav>
 </header>
 
@@ -95,10 +99,8 @@ section{margin-bottom:32px}
 </main>
 
 <footer>
-  © 2025 Read-Aloud ·
-  <a href="../privacy.html">Privacy</a> ·
-  <a href="../contact.html">Contact</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -23,15 +23,17 @@
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html" aria-current="page">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>About Read‑Aloud</h1>
@@ -122,8 +124,8 @@
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/audio.html
+++ b/audio.html
@@ -6,6 +6,18 @@
   <title>Audio Stream</title>
 </head>
 <body>
+<header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
   <h1>Embedded Audio Stream</h1>
   <p>Listen to the station below:</p>
 
@@ -20,8 +32,9 @@
   <!-- Link to go back to your homepage -->
   <p><a href="index.html">Back to Home</a></p>
 
-  <footer style="margin-top:24px; text-align:center; font-size:0.9em; color:#444;">
-    As an Amazon Associate I earn from qualifying purchases.
-  </footer>
+  <footer>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+</footer>
 </body>
 </html>

--- a/benefits.html
+++ b/benefits.html
@@ -10,15 +10,17 @@
 <body>
   <!-- HEADER -->
   <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
   <!-- MAIN CONTENT: Benefits Section -->
   <main>
@@ -43,17 +45,8 @@
 
   <!-- FOOTER -->
   <footer>
-    <div class="container">
-      <p>&copy; 2025 Read-Aloud.com. All rights reserved.</p>
-        <nav>
-          <ul>
-            <li><a href="privacy.html">Privacy Policy</a></li>
-            <li><a href="terms.html">Terms of Use</a></li>
-            <li><a href="contact.html">Contact</a></li>
-          </ul>
-        </nav>
-      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
-    </div>
-  </footer>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+</footer>
 </body>
 </html>

--- a/benifits.html
+++ b/benifits.html
@@ -10,15 +10,17 @@
 <body>
   <!-- HEADER -->
   <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
   <!-- MAIN CONTENT: Benefits Section -->
   <main>
@@ -43,17 +45,8 @@
 
   <!-- FOOTER -->
   <footer>
-    <div class="container">
-      <p>&copy; 2025 Read-Aloud.com. All rights reserved.</p>
-      <nav>
-        <ul>
-          <li><a href="/privacy">Privacy Policy</a></li>
-          <li><a href="/terms">Terms of Use</a></li>
-          <li><a href="/contact">Contact</a></li>
-        </ul>
-      </nav>
-      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
-    </div>
-  </footer>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+</footer>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -10,15 +10,17 @@
 <body>
   <!-- HEADER -->
   <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
   <!-- MAIN CONTENT: Blog Posts -->
   <main>
@@ -51,17 +53,8 @@
 
   <!-- FOOTER -->
   <footer>
-    <div class="container">
-      <p>&copy; 2025 Read-Aloud.com. All rights reserved.</p>
-      <nav>
-        <ul>
-          <li><a href="/privacy">Privacy Policy</a></li>
-          <li><a href="/terms">Terms of Use</a></li>
-          <li><a href="/contact">Contact</a></li>
-        </ul>
-      </nav>
-      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
-    </div>
-  </footer>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+</footer>
 </body>
 </html>

--- a/bookmark.html
+++ b/bookmark.html
@@ -139,6 +139,18 @@
     </style>
 </head>
 <body>
+<header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
     <h1>Text-to-Speech Reader</h1>
     <p>Type or paste your text below to hear it read aloud.</p>
 
@@ -367,8 +379,9 @@
 
     </script>
 
-    <footer style="margin-top:24px; text-align:center;">
-        <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
-    </footer>
+    <footer>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+</footer>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -19,15 +19,17 @@ button{margin-top:12px;padding:10px 18px;background:#ff0;border:2px solid #777;f
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Contact Us</h1>
@@ -52,8 +54,8 @@ button{margin-top:12px;padding:10px 18px;background:#ff0;border:2px solid #777;f
 </main>
 
 <footer>
-  © 2025 Read-Aloud
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/download-mp3.html
+++ b/download-mp3.html
@@ -35,6 +35,18 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lamejs/1.2.1/lame.min.js"></script>
 </head>
 <body>
+<header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
   <nav>
     <a href="index.html">Home</a>
     <a href="voices.html">Voices</a>
@@ -128,9 +140,9 @@
   </div>
 
   <footer>
-    © 2025 Read‑Aloud · <a href="/terms.html">Terms</a>
-    <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
-  </footer>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+</footer>
 
 <script>
 (function () {

--- a/faq.html
+++ b/faq.html
@@ -21,15 +21,17 @@
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Frequently Asked Questions (FAQ)</h1>
@@ -81,8 +83,8 @@
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/guide-browser-compatibility.html
+++ b/guide-browser-compatibility.html
@@ -26,15 +26,17 @@ hr{margin:24px 0}
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Browser Compatibility &amp; Voice Availability (Read‑Aloud)</h1>
@@ -169,8 +171,8 @@ hr{margin:24px 0}
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/guide-dyslexia-adhd.html
+++ b/guide-dyslexia-adhd.html
@@ -22,15 +22,17 @@ hr{margin:24px 0}
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Text‑to‑Speech for Dyslexia &amp; ADHD (Practical Strategies)</h1>
@@ -125,8 +127,8 @@ hr{margin:24px 0}
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/guide-how-to-use.html
+++ b/guide-how-to-use.html
@@ -26,15 +26,17 @@ kbd{border:1px solid #bbb;border-bottom:2px solid #999;border-radius:6px;padding
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>How to Use Read‑Aloud (Step‑by‑Step)</h1>
@@ -110,8 +112,8 @@ Question: does it pause correctly after commas, periods, and question marks?</pr
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/guide-language-learning.html
+++ b/guide-language-learning.html
@@ -24,15 +24,17 @@ hr{margin:24px 0}
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Language Learning With Text‑to‑Speech</h1>
@@ -142,8 +144,8 @@ FRANÇAIS (French)
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/guide-mp3-export.html
+++ b/guide-mp3-export.html
@@ -26,15 +26,17 @@
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Known limitations: Why MP3 export is hard in browser text‑to‑speech</h1>
@@ -136,8 +138,8 @@
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/guide-privacy.html
+++ b/guide-privacy.html
@@ -24,15 +24,17 @@ hr{margin:24px 0}
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Privacy‑First Text‑to‑Speech: What Stays On Your Device</h1>
@@ -115,8 +117,8 @@ hr{margin:24px 0}
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/guide-proofread.html
+++ b/guide-proofread.html
@@ -24,15 +24,17 @@ hr{margin:24px 0}
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Proofread by Ear: Use Text‑to‑Speech to Edit Faster</h1>
@@ -140,8 +142,8 @@ hr{margin:24px 0}
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/guide-study.html
+++ b/guide-study.html
@@ -24,15 +24,17 @@ hr{margin:24px 0}
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Study With Text‑to‑Speech (Notes, Articles, Assignments)</h1>
@@ -155,8 +157,8 @@ Next step (choose one):
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/guides-how-to-use.html
+++ b/guides-how-to-use.html
@@ -23,15 +23,17 @@ hr{margin:24px 0}
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>How to Use Read‑Aloud (Step‑by‑Step)</h1>
@@ -125,8 +127,8 @@ hr{margin:24px 0}
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/guides.html
+++ b/guides.html
@@ -23,15 +23,17 @@ hr{margin:24px 0}
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html" aria-current="page">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Guides &amp; Tutorials</h1>
@@ -96,8 +98,8 @@ hr{margin:24px 0}
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/help.html
+++ b/help.html
@@ -20,15 +20,17 @@ dl dt{font-weight:700;margin-top:12px}
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html" aria-current="page">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Help &amp; Frequently Asked Questions</h1>
@@ -77,8 +79,8 @@ dl dt{font-weight:700;margin-top:12px}
 </main>
 
 <footer>
-  © 2025 Read-Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -10,15 +10,17 @@
 <body>
   <!-- HEADER -->
   <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
   <!-- MAIN CONTENT: How It Works -->
   <main>
@@ -37,17 +39,8 @@
 
   <!-- FOOTER -->
   <footer>
-    <div class="container">
-      <p>&copy; 2025 Read-Aloud.com. All rights reserved.</p>
-      <nav>
-        <ul>
-          <li><a href="/privacy">Privacy Policy</a></li>
-          <li><a href="/terms">Terms of Use</a></li>
-          <li><a href="/contact">Contact</a></li>
-        </ul>
-      </nav>
-      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
-    </div>
-  </footer>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+</footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -54,15 +54,19 @@ footer .small{display:block;font-size:12px;color:#e0e0ff;margin-top:4px}
 <body>
 
 <!-- header -->
-<div id="top"><h1>Read-Aloud</h1></div>
+<header>
+  <div id="top"><h1>Read-Aloud</h1></div>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
+    <a href="index.html" aria-current="page">Home</a>
     <a href="voices.html">Voices</a>
     <a href="help.html">Help</a>
     <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
     <a href="about.html">About</a>
     <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
   </nav>
+</header>
 
 <!-- support bar -->
 <div id="supportBar" role="region" aria-label="Support Read-Aloud">
@@ -272,11 +276,8 @@ function updateBar(visits){
 
 <!-- footer -->
 <footer>
-  © 2025 Read-Aloud ·
-  <a href="https://coff.ee/readaloud" target="_blank" rel="noopener">Buy me a coffee</a> ·
-  <a href="privacy.html">Privacy</a> ·
-  <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -23,13 +23,15 @@
 
 <body>
 <header>
-  <nav>
+  <nav id="mainNav">
     <a href="index.html">Home</a>
     <a href="voices.html">Voices</a>
     <a href="help.html">Help</a>
     <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
     <a href="about.html">About</a>
     <a href="privacy.html" aria-current="page">Privacy</a>
+    <a href="terms.html">Terms</a>
   </nav>
 </header>
 
@@ -88,7 +90,6 @@
     When you click an affiliate link, the third‑party site may use cookies or similar tracking to attribute purchases.
     Their privacy policy applies on their site.
   </p>
-  <p><strong>As an Amazon Associate I earn from qualifying purchases.</strong></p>
 
   <h2>4) Advertising</h2>
   <div class="box">
@@ -150,11 +151,11 @@
   <p class="small">
     © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
   </p>
-  <p class="small"><strong>As an Amazon Associate I earn from qualifying purchases.</strong></p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/read-aloud-premium/public/premium.html
+++ b/read-aloud-premium/public/premium.html
@@ -8,6 +8,18 @@
     <link rel="stylesheet" href="voices.css">
   </head>
   <body>
+<header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
     <main class="wrap">
       <h1>Premium Voices</h1>
       <p>
@@ -46,9 +58,10 @@
       <div id="download" style="margin-top: 16px;"></div>
     </main>
 
-    <footer class="wrap">
-      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
-    </footer>
+    <footer>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+</footer>
 
     <script>window.API_BASE = 'https://api.read-aloud.com';</script>
 <script src="premium.js"></script>

--- a/read-aloud-premium/public/voices.html
+++ b/read-aloud-premium/public/voices.html
@@ -7,6 +7,18 @@
     <link rel="stylesheet" href="voices.css">
   </head>
   <body>
+<header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html" aria-current="page">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
     <main class="wrap">
       <h1>Voice Demos</h1>
       <p>Select a voice and click <strong>Play</strong> to hear a short sample. You can also provide your own text for the preview.</p>
@@ -19,9 +31,10 @@
         <audio id="audio" controls preload="none"></audio>
       </div>
     </main>
-    <footer class="wrap">
-      <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
-    </footer>
+    <footer>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+</footer>
 <script>window.API_BASE = 'https://api.read-aloud.com';</script>
 
     <script src="voices.js"></script>

--- a/recommendations.html
+++ b/recommendations.html
@@ -29,13 +29,15 @@
 
 <body>
 <header>
-  <nav>
+  <nav id="mainNav">
     <a href="index.html">Home</a>
     <a href="voices.html">Voices</a>
     <a href="help.html">Help</a>
     <a href="guides.html">Guides</a>
+    <a href="recommendations.html" aria-current="page">Recommendations</a>
     <a href="about.html">About</a>
     <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
   </nav>
 </header>
 
@@ -50,7 +52,7 @@
   </p>
 
   <div class="highlight">
-    <p style="margin:0 0 8px 0"><strong>Affiliate disclosure:</strong> As an Amazon Associate I earn from qualifying purchases.</p>
+    <p style="margin:0 0 8px 0"><strong>Affiliate disclosure:</strong></p>
     <p class="small" style="margin:0">
       If you buy through a link, it helps cover hosting and maintenance at no extra cost to you.
       I try to keep recommendations practical and not spammy.
@@ -310,12 +312,12 @@
   </p>
 
   <p class="small">
-    Reminder: <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
-  </p>
+    Reminder:</p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/support.html
+++ b/support.html
@@ -9,6 +9,18 @@ form{max-width:500px}
 .small{font-size:0.9em;color:#444;margin-top:16px}
 </style>
 </head><body>
+<header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 <h1>Contact Us</h1>
 <form action="https://formspree.io/f/yourFormID" method="POST">
 <label>Name<br><input type="text" name="name" required></label><br><br>
@@ -18,6 +30,7 @@ form{max-width:500px}
 </form>
 <p>Email: support@read-aloud.com</p>
 <footer>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body></html>

--- a/terms.html
+++ b/terms.html
@@ -23,11 +23,12 @@
 
 <body>
 <header>
-  <nav>
+  <nav id="mainNav">
     <a href="index.html">Home</a>
     <a href="voices.html">Voices</a>
     <a href="help.html">Help</a>
     <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
     <a href="about.html">About</a>
     <a href="privacy.html">Privacy</a>
     <a href="terms.html" aria-current="page">Terms</a>
@@ -95,9 +96,7 @@
     We do not control third‑party sites and are not responsible for their content, policies, or practices.
   </p>
   <p>
-    Some links may be affiliate links that help support the site.
-    <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
-  </p>
+    Some links may be affiliate links that help support the site.</p>
 
   <h2>7) Advertising</h2>
   <p>
@@ -159,7 +158,8 @@
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>
 </html>

--- a/texttospeech.html
+++ b/texttospeech.html
@@ -8,6 +8,18 @@
 <script src="https://unpkg.com/mespeak/mespeak.min.js"></script>
 </head>
 <body>
+<header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
     <h1>Text-to-Speech Reader</h1>
     <p>Type or paste your text below to hear it read aloud.</p>
 
@@ -290,8 +302,9 @@ mespeak.loadVoice("https://unpkg.com/mespeak/voices/en/en.json",()=>{window.mesp
 
     </script>
 
-    <footer style="margin-top:24px; text-align:center;">
-        <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
-    </footer>
+    <footer>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+</footer>
 </body>
 </html>

--- a/voices.html
+++ b/voices.html
@@ -21,15 +21,17 @@ button.demo{width:100%;padding:10px;background:#ff0;border:2px solid #777;cursor
 
 <body>
 <header>
-      <nav aria-label="Primary">
-        <a href="index.html">Home</a>
-        <a href="voices.html">Voices</a>
-        <a href="help.html">Help</a>
-        <a href="guides.html">Guides</a>
-        <a href="about.html">About</a>
-        <a href="privacy.html">Privacy</a>
-      </nav>
-    </header>
+  <nav id="mainNav">
+    <a href="index.html">Home</a>
+    <a href="voices.html" aria-current="page">Voices</a>
+    <a href="help.html">Help</a>
+    <a href="guides.html">Guides</a>
+    <a href="recommendations.html">Recommendations</a>
+    <a href="about.html">About</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+  </nav>
+</header>
 
 <main>
   <h1>Voice Gallery</h1>
@@ -59,10 +61,8 @@ button.demo{width:100%;padding:10px;background:#ff0;border:2px solid #777;cursor
 </main>
 
 <footer>
-  © 2025 Read-Aloud ·
-  <a href="contact.html">Contact</a> ·
-  <a href="terms.html">Terms</a>
-  <div class="small">As an Amazon Associate I earn from qualifying purchases.</div>
+  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 
 <script>


### PR DESCRIPTION
## Summary
- Align header navigation across all HTML pages to the canonical link order with appropriate aria-current markers
- Replace every page footer with the canonical disclosure and remove duplicate Amazon Associate notices

## Testing
- Not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f032491c88331b3231cee808285ae)