### PR TITLE
Remove premium TTS integrations

### DIFF
--- a/read-aloud-premium/server/premium_api.py
+++ b/read-aloud-premium/server/premium_api.py
@@ -1,70 +1,22 @@
 #!/usr/bin/env python3
-# premium_api.py — Free voice previews and paid MP3 generation via Stripe
+# premium_api.py — Stripe utilities with preview/generation disabled
 
-"""FastAPI application for premium voice previews and one‑off MP3 purchases.
+"""FastAPI application for premium checkout utilities.
 
-This module defines a small web API with three main features:
-
-* ``/api/voices`` – List available voices for preview and generation.
-* ``/api/preview`` – Synthesize a short preview (limited to 300
-  characters) using any available voice. Responses are cached on
-  disk to avoid repeated TTS requests for identical inputs.
-* ``/api/file/{fname}`` – Serve cached preview MP3s and paid MP3s.
-* ``/api/premium/checkout`` – Create a Stripe Checkout session for a
-  one‑off premium MP3 purchase.
-* ``/api/premium/mark_paid`` – Verify a Checkout session and mark it
-  as paid (simplified MVP; in production use a Stripe webhook).
-* ``/api/premium/generate`` – After payment, synthesize the full
-  requested text and return a download link for the generated MP3.
-
-Environment variables:
-
-* ``STRIPE_SECRET_KEY`` – Your Stripe secret key.
-* ``STRIPE_PUBLISHABLE_KEY`` – Your Stripe publishable key (not used
-  directly by the backend but may be consumed by the frontend).
-* ``STRIPE_PRICE_ID`` – The ID of a one‑time price in Stripe for the
-  premium MP3 product.
-* ``PREMIUM_SUCCESS_URL`` – URL template for redirect after a
-  successful checkout. Should contain ``{CHECKOUT_SESSION_ID}`` which
-  will be replaced by Stripe.
-* ``PREMIUM_CANCEL_URL`` – URL to redirect to on cancellation.
-
-Dependencies:
-
-This API relies on ``fastapi``, ``uvicorn``, ``stripe``, and the
-``read-aloud-premium.server.providers`` and ``read-aloud-premium.server.store``
-modules. Ensure these are installed and configured properly.
+Premium text-to-speech endpoints have been disabled to avoid sending
+user text to external services. The API still exposes Stripe checkout
+helpers and a placeholder voice listing for compatibility.
 """
 
 import os
-import hashlib
-import pathlib
-import time
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException, Query, Body
-from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
-from .providers import list_public_voices, synth
+from .providers import list_public_voices
 from . import store
 
-
-# Directory configuration. The preview cache and generated outputs are
-# stored under ``cache/previews`` and ``out`` directories relative to
-# this file. Make sure these directories are writable by the server.
-BASE_DIR = pathlib.Path(__file__).resolve().parent
-CACHE_DIR = BASE_DIR / "cache" / "previews"
-OUT_DIR = BASE_DIR / "out"
-CACHE_DIR.mkdir(parents=True, exist_ok=True)
-OUT_DIR.mkdir(parents=True, exist_ok=True)
-
-# Limits for preview and full generation. Adjust these values if you
-# need longer previews or allow longer paid syntheses. Text exceeding
-# these limits will cause an HTTP 400 response.
-PREVIEW_MAX_CHARS = 300     # roughly 10–15 seconds
-GENERATE_MAX_CHARS = 20000  # safety cap for paid usage
-DEFAULT_PREVIEW_TEXT = "This is a short voice preview from read‑aloud dot com."
 
 # Stripe configuration from environment
 STRIPE_SECRET = os.getenv("STRIPE_SECRET_KEY", "").strip()
@@ -102,7 +54,7 @@ app.add_middleware(
 )
 
 
-
+ 
 
 # Pydantic models for request/response validation
 class VoicesOut(BaseModel):
@@ -124,15 +76,6 @@ class GenerateIn(BaseModel):
     rate: float = 1.0
 
 
-# Helper to compute deterministic file names based on content. This
-# ensures that identical preview requests hit the same cache file and
-# that paid outputs are uniquely named per session.
-def _hash_name(prefix: str, payload: str) -> pathlib.Path:
-    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
-    directory = OUT_DIR if prefix == "paid" else CACHE_DIR
-    return directory / f"{prefix}_{digest}.mp3"
-
-
 @app.get("/api/voices", response_model=VoicesOut)
 def voices() -> dict:
     """Return the list of available voices for preview and generation."""
@@ -145,32 +88,13 @@ def preview(
     text: Optional[str] = None,
     rate: float = Query(1.0, ge=0.5, le=1.5),
 ) -> dict:
-    """Synthesize a short preview.
+    """Placeholder preview endpoint with TTS disabled."""
 
-    This endpoint truncates the requested text to ``PREVIEW_MAX_CHARS``
-    and caches the resulting MP3 to avoid duplicate provider calls.
-    """
-    sample = (text or DEFAULT_PREVIEW_TEXT).strip()
-    if len(sample) > PREVIEW_MAX_CHARS:
-        sample = sample[:PREVIEW_MAX_CHARS]
-    # Check cache
-    cache_file = _hash_name("demo", f"{voice}|{rate}|{sample}")
-    if cache_file.exists() and cache_file.stat().st_size > 1000:
-        return {"url": f"/api/file/{cache_file.name}", "cached": True}
-    # Generate preview
-    audio = synth(sample, voice, speaking_rate=rate)
-    cache_file.write_bytes(audio)
-    return {"url": f"/api/file/{cache_file.name}", "cached": False}
-
-
-@app.get("/api/file/{fname}")
-def serve_file(fname: str) -> FileResponse:
-    """Serve an MP3 file from the cache or paid output directory."""
-    directory = OUT_DIR if fname.startswith("paid_") else CACHE_DIR
-    path = directory / fname
-    if not path.exists():
-        raise HTTPException(status_code=404, detail="File not found")
-    return FileResponse(str(path), media_type="audio/mpeg", filename=fname)
+    _ = (voice, text, rate)
+    raise HTTPException(
+        status_code=503,
+        detail="Voice previews are currently disabled and no audio is generated.",
+    )
 
 
 @app.post("/api/premium/checkout", response_model=CheckoutOut)
@@ -222,27 +146,10 @@ def mark_paid(session_id: str = Body(..., embed=True)) -> dict:
 
 @app.post("/api/premium/generate")
 def generate(req: GenerateIn) -> dict:
-    """Synthesize the full MP3 after payment.
+    """Placeholder generation endpoint with premium TTS disabled."""
 
-    This endpoint checks that the provided ``session_id`` has been paid
-    and not yet used. It then synthesizes the full text using the
-    requested voice and returns a download link. Once used, the
-    session is marked as used to prevent reuse.
-    """
-    text = req.text.strip()
-    if not text:
-        raise HTTPException(status_code=400, detail="Empty text")
-    if len(text) > GENERATE_MAX_CHARS:
-        raise HTTPException(status_code=400, detail="Text too long")
-    if not store.is_paid_and_unused(req.session_id):
-        raise HTTPException(
-            status_code=402, detail="Payment required or already used"
-        )
-    # Generate audio
-    audio = synth(text, req.voice, speaking_rate=req.rate)
-    # Save to disk
-    fname = _hash_name("paid", f"{time.time()}|{req.session_id}|{req.voice}")
-    fname.write_bytes(audio)
-    # Mark as used
-    store.mark_used(req.session_id)
-    return {"download": f"/api/file/{fname.name}"}
+    _ = req
+    raise HTTPException(
+        status_code=503,
+        detail="Premium text-to-speech generation is disabled; no audio is produced.",
+    )

--- a/read-aloud-premium/server/providers.py
+++ b/read-aloud-premium/server/providers.py
@@ -1,144 +1,21 @@
 #!/usr/bin/env python3
-# providers.py — TTS adapters for Google + ElevenLabs
+# providers.py — placeholder voice registry
 
-"""Text-to-speech provider adapters for Google Cloud and ElevenLabs.
+"""Placeholder provider registry with external TTS disabled.
 
-This module exposes a simple API for synthesizing speech using either
-Google Cloud Text-to-Speech or ElevenLabs. It also defines a minimal
-voice registry used by the premium demo and paid endpoints. Each entry
-in the ``VOICES`` dictionary contains metadata about the voice,
-including whether it should be considered premium and the default
-speaking rate. Providers not configured (e.g. ElevenLabs without an
-API key) will raise a ``RuntimeError`` when invoked.
+Premium text-to-speech integrations have been removed. This module now
+only exposes a stub ``list_public_voices`` helper so the API can respond
+without attempting to contact external services.
 """
 
-import os
-import pathlib
 from typing import Dict, Any
 
-# Directory where any cache or temporary files could be stored. This
-# ensures the directory exists on import. In production you may wish
-# to direct this to a persistent location such as an S3 bucket.
-CACHE_DIR = pathlib.Path(__file__).resolve().parent / "cache"
-CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
-# Voice registry. Each voice entry uses a unique key. The values
-# include the provider ("google" or "elevenlabs"), a human‑friendly
-# label, the provider-specific voice identifier, a ``premium`` flag,
-# and a default speaking rate. Feel free to expand this list with
-# additional languages and voices as needed.
-VOICES: Dict[str, Dict[str, Any]] = {
-    # Google Neural voices (high quality, reasonable cost). These
-    # voices use the Neural2 engine. See Google Cloud docs for
-    # additional voice names.
-    "google_en_us_neural_f": {
-        "provider": "google",
-        "label": "English (US) — Female — Neural2-F",
-        "voice_name": "en-US-Neural2-F",
-        "premium": False,
-        "rate_default": 1.0,
-    },
-    "google_en_us_neural_m": {
-        "provider": "google",
-        "label": "English (US) — Male — Neural2-M",
-        "voice_name": "en-US-Neural2-M",
-        "premium": False,
-        "rate_default": 1.0,
-    },
+# Empty voice registry maintained for compatibility with the API
+VOICES: Dict[str, Dict[str, Any]] = {}
 
-    # Example ElevenLabs voice. To enable this, set the
-    # ELEVENLABS_API_KEY environment variable. Replace the
-    # ``voice_id`` with a voice from your ElevenLabs account.
-    "11labs_rachel": {
-        "provider": "elevenlabs",
-        "label": "ElevenLabs — Rachel (Premium)",
-        "voice_id": "21m00Tcm4TlvDq8ikWAM",
-        "premium": True,
-        "rate_default": 1.0,
-    },
-}
 
 def list_public_voices() -> list:
-    """Return a list of public voice metadata.
+    """Return a list of available voices (currently none)."""
 
-    Each element is a dict containing the key, label and whether the
-    voice is premium. This is used by the API to expose available
-    voices to clients.
-    """
-    return [
-        {"key": key, "label": data["label"], "premium": data["premium"]}
-        for key, data in VOICES.items()
-    ]
-
-
-def synth(text: str, key: str, speaking_rate: float = 1.0) -> bytes:
-    """Synthesize speech using the specified voice.
-
-    Args:
-        text: The text to synthesize. Should already be validated and
-            length‑restricted by the caller.
-        key: The key identifying the voice to use.
-        speaking_rate: Optional speaking rate multiplier. A value of
-            1.0 produces normal speed; adjust between 0.5 and 1.5.
-
-    Returns:
-        MP3 audio bytes.
-
-    Raises:
-        ValueError: If the voice key is unknown.
-        RuntimeError: If the requested provider is unsupported or not
-            configured.
-    """
-    voice = VOICES.get(key)
-    if not voice:
-        raise ValueError(f"Unknown voice key: {key}")
-
-    provider = voice["provider"]
-    if provider == "google":
-        # Use Google Cloud Text-to-Speech. Requires the client library
-        # and credentials file configured via the
-        # GOOGLE_APPLICATION_CREDENTIALS environment variable.
-        from google.cloud import texttospeech as tts
-        
-        input_text = tts.SynthesisInput(text=text)
-        voice_params = tts.VoiceSelectionParams(
-            language_code="en-US", name=voice["voice_name"]
-        )
-        audio_cfg = tts.AudioConfig(
-            audio_encoding=tts.AudioEncoding.MP3,
-            speaking_rate=speaking_rate,
-        )
-        response = client.synthesize_speech(
-            input=input_text, voice=voice_params, audio_config=audio_cfg
-        )
-        return response.audio_content
-
-    if provider == "elevenlabs":
-        # Use ElevenLabs via HTTP API. Requires ELEVENLABS_API_KEY.
-        api_key = os.getenv("ELEVENLABS_API_KEY", "").strip()
-        if not api_key:
-            raise RuntimeError(
-                "ELEVENLABS_API_KEY not set. Premium voices are disabled."
-            )
-        import httpx
-        import json
-        url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice['voice_id']}"
-        headers = {
-            "xi-api-key": api_key,
-            "accept": "audio/mpeg",
-            "Content-Type": "application/json",
-        }
-        payload = {
-            "text": text,
-            "model_id": "eleven_turbo_v2",
-            "voice_settings": {"stability": 0.5, "similarity_boost": 0.75},
-        }
-        with httpx.Client(timeout=90) as client:
-            resp = client.post(url, headers=headers, data=json.dumps(payload))
-            if resp.status_code != 200:
-                raise RuntimeError(
-                    f"ElevenLabs {resp.status_code}: {resp.text[:200]}"
-                )
-            return resp.content
-
-    raise RuntimeError(f"Unsupported provider: {provider}")
+    return []


### PR DESCRIPTION
## Summary
- remove external TTS provider helpers and voice registry in the premium server
- disable preview and premium generation endpoints to avoid sending text to third parties
- keep Stripe checkout and status flows while cleaning unused premium code paths

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69416830908c8331876ad47e13e6a4eb)