### PR TITLE
Add Google Analytics tag to site pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>About | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/audio.html
+++ b/audio.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Audio Stream</title>

--- a/benefits.html
+++ b/benefits.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Benefits | Read-Aloud</title>

--- a/benifits.html
+++ b/benifits.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Benefits | Read-Aloud</title>

--- a/blog.html
+++ b/blog.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Blog | Read-Aloud</title>

--- a/bookmark.html
+++ b/bookmark.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Text-to-Speech Website</title>

--- a/contact.html
+++ b/contact.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Contact | Read-Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/download-mp3.html
+++ b/download-mp3.html
@@ -1,6 +1,16 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Download MP3 (Offline Voice) · Read‑Aloud</title>

--- a/faq.html
+++ b/faq.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>FAQ | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/guide-browser-compatibility.html
+++ b/guide-browser-compatibility.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Browser Compatibility & Voice Availability | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/guide-dyslexia-adhd.html
+++ b/guide-dyslexia-adhd.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Text‑to‑Speech for Dyslexia & ADHD | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/guide-how-to-use.html
+++ b/guide-how-to-use.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>How to Use Read‑Aloud (Step‑by‑Step) | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/guide-language-learning.html
+++ b/guide-language-learning.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Language Learning with Text‑to‑Speech | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/guide-mp3-export.html
+++ b/guide-mp3-export.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Why MP3 Export Is Hard in Browser TTS | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/guide-privacy.html
+++ b/guide-privacy.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Privacy‑First Text‑to‑Speech | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/guide-proofread.html
+++ b/guide-proofread.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Proofread by Ear (Text‑to‑Speech Editing) | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/guide-study.html
+++ b/guide-study.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Study With Text‑to‑Speech | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/guides-how-to-use.html
+++ b/guides-how-to-use.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>How to Use Read‑Aloud (Step‑by‑Step) | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/guides.html
+++ b/guides.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Guides & Tutorials | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/help.html
+++ b/help.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Help & FAQ | Read-Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>How It Works | Read-Aloud</title>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">

--- a/privacy.html
+++ b/privacy.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Privacy Policy | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/read-aloud-premium/public/premium.html
+++ b/read-aloud-premium/public/premium.html
@@ -1,6 +1,16 @@
 <!doctype html>
 <html>
   <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
     <meta charset="utf-8"/>
     <title>Premium Voices • read‑aloud</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/read-aloud-premium/public/voices.html
+++ b/read-aloud-premium/public/voices.html
@@ -1,6 +1,16 @@
 <!doctype html>
 <html>
   <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
     <meta charset="utf-8"/>
     <title>Voice Demos • read‑aloud</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/recommendations.html
+++ b/recommendations.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Recommended Reading Aids & Accessories | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/support.html
+++ b/support.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8"><title>Contact | Read-Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <style>

--- a/terms.html
+++ b/terms.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Terms of Use | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/texttospeech.html
+++ b/texttospeech.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Text-to-Speech Website</title>

--- a/voices.html
+++ b/voices.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SVGML1VGPG');
+</script>
+
 <meta charset="utf-8">
 <title>Voice Gallery | Read-Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
## Summary
- add the Google Analytics gtag snippet to all public HTML pages, including premium pages

## Testing
- not run (static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69456d69644883318d8dab69863d2878)