### PR TITLE
Restore Google tag on study use page

### DIFF
--- a/Uses/proofreading.html
+++ b/Uses/proofreading.html
@@ -3,38 +3,37 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Proofread by Ear | Read‑Aloud</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Use Read‑Aloud to proofread drafts. Steps for setup, pacing, and catching awkward sentences by ear." />
-  <link rel="canonical" href="https://www.read-aloud.com/Uses/proofreading.html">
-  <link rel="stylesheet" href="../site.css">
+  <link rel="canonical" href="https://read-aloud.com/Uses/proofreading.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="../index.html">Home</a>
-      <a href="../app.html">Tool</a>
-      <a href="../guides.html">Guides</a>
-      <a href="../help.html">Help</a>
-      <a href="../voices.html">Voices</a>
-      <a href="../about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> Proofreading</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Proofreading</div>
   <h1>Proofread by Ear</h1>
   <p class="lead">Listening reveals issues that silent reading misses. Use these steps to turn Read‑Aloud into a reliable editing companion.</p>
 
   <section class="card">
     <h2>Setup</h2>
     <ul>
-      <li>Open the <a href="../app.html">tool</a> and paste 400–800 words from your draft.</li>
+      <li>Open the <a href="/app.html">tool</a> and paste 400–800 words from your draft.</li>
       <li>Pick a voice that differs from your own so mistakes stand out.</li>
       <li>Set speed to 0.95–1.05× depending on density.</li>
       <li>Bookmark the page so you can run a quick listen after every writing session.</li>
@@ -61,27 +60,27 @@
   <section class="related">
     <h3>Related guides</h3>
     <ul>
-      <li><a href="../guides/tts-for-writers.html">TTS for Writers</a></li>
-      <li><a href="../guides/tts-voice-selection.html">Voice Selection</a></li>
-      <li><a href="../guides/tts-study-loop-templates.html">Proofreading sprint template</a></li>
+      <li><a href="/guides/tts-for-writers.html">TTS for Writers</a></li>
+      <li><a href="/guides/tts-voice-selection.html">Voice Selection</a></li>
+      <li><a href="/guides/tts-study-loop-templates.html">Proofreading sprint template</a></li>
     </ul>
   </section>
 </main>
 
 <footer>
   <div>
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../about.html">About</a>
-    <a href="../contact.html">Contact</a>
-    <a href="../privacy.html">Privacy</a>
-    <a href="../terms.html">Terms</a>
-    <a href="../privacy.html#controls">Privacy settings</a>
-    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="../sitemap.xml">Sitemap</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/privacy.html#controls">Privacy settings</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Proofread safely in your browser.</div>
 </footer>

--- a/Uses/proofreading.html
+++ b/Uses/proofreading.html
@@ -1,86 +1,89 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<title>Proofread by Ear | Read-Aloud</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="description" content="Catch rhythm glitches, missing words and awkward phrasing by listening to your draft instead of staring at the screen.">
-<style>
-body{margin:0;font:16px/1.6 Arial,Helvetica,sans-serif;background:#f5f9ff;color:#111}
-header,footer{background:#004080;color:#fff;padding:14px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
-main{max-width:940px;margin:auto;padding:24px}
-h1{margin-top:0;font-size:1.9em}
-.tip{background:#fff;border-left:5px solid #004080;margin:20px 0;padding:14px}
-.ads{margin:36px auto;text-align:center}
-.small{font-size:0.9em;color:#e0e0e0}
-</style>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Proofread by Ear | Read‑Aloud</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Use Read‑Aloud to proofread drafts. Steps for setup, pacing, and catching awkward sentences by ear." />
+  <link rel="canonical" href="https://www.read-aloud.com/Uses/proofreading.html">
+  <link rel="stylesheet" href="../site.css">
 </head>
-
 <body>
 <header>
-  <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="../index.html">Home</a>
+      <a href="../app.html">Tool</a>
+      <a href="../guides.html">Guides</a>
+      <a href="../help.html">Help</a>
+      <a href="../voices.html">Voices</a>
+      <a href="../about.html">About</a>
+    </nav>
+  </div>
 </header>
 
 <main>
-  <h1>Proofread Your Writing by Ear</h1>
+  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> Proofreading</div>
+  <h1>Proofread by Ear</h1>
+  <p class="lead">Listening reveals issues that silent reading misses. Use these steps to turn Read‑Aloud into a reliable editing companion.</p>
 
-  <p>When you read a draft silently, your brain auto-corrects missing words and glosses over clumsy phrasing.  
-     Listening to your text forces every syllable through a fresh channel—ideal for spotting hidden errors.</p>
+  <section class="card">
+    <h2>Setup</h2>
+    <ul>
+      <li>Open the <a href="../app.html">tool</a> and paste 400–800 words from your draft.</li>
+      <li>Pick a voice that differs from your own so mistakes stand out.</li>
+      <li>Set speed to 0.95–1.05× depending on density.</li>
+      <li>Bookmark the page so you can run a quick listen after every writing session.</li>
+    </ul>
+  </section>
 
-  <div class="tip">
-    <strong>Quick setup:</strong> Paste your draft into the <a href="../index.html">home page</a>, choose a neutral voice,
-    set the speed to 0.95×, and press <kbd>Start</kbd>.  
-    Keep your text on screen so you can pause and edit in real time.
-  </div>
+  <section class="card">
+    <h2>While listening</h2>
+    <p>Keep a notepad for quick tags such as <strong>[awk]</strong> for awkward sentences or <strong>[ex]</strong> where you owe an example. Pause with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> when you hear something odd, jot the tag, then resume.</p>
+    <p class="small">If you are editing dialogue, note the character name beside each tag so you can review voice consistency later.</p>
+  </section>
 
-  <h2>Five errors you’ll catch by listening</h2>
-  <ol>
-    <li><strong>Double words</strong> (e.g., “the the”)—sounds like a stutter.</li>
-    <li><strong>Missing articles</strong> (“go to store”)—voice highlights the gap.</li>
-    <li><strong>Run-on sentences</strong>—you’ll hear yourself run out of breath.</li>
-    <li><strong>Tongue-twisters / awkward rhythm</strong>—rewrite for flow.</li>
-    <li><strong>Inconsistent tense or POV</strong>—shifts jump out aloud.</li>
-  </ol>
+  <section class="card">
+    <h2>After the pass</h2>
+    <p>Return to your draft and resolve tags in order: cut filler words, swap verbs, and add missing examples. Run a final listen at a slightly faster speed to catch lingering issues.</p>
+    <p>
+      For long projects, keep a running list of phrases you overuse. The next time you listen, keep that
+      list nearby and pause whenever you hear a repeat. Over time you will build your own personal style
+      guide that shortens future editing sessions.
+    </p>
+    <p class="small">Before publishing, listen to your introduction one more time on mobile speakers to ensure the hook sounds clear.</p>
+  </section>
 
-  <h2>Workflow used by professional editors</h2>
-  <ul>
-    <li><strong>Pass 1:</strong> Listen to full piece, jot quick notes only.</li>
-    <li><strong>Pass 2:</strong> Fix notes, then listen again at 1.1× to check pacing.</li>
-    <li><strong>Final pass:</strong> Export an MP3 and proof it on your phone during a walk.</li>
-  </ul>
-
-  <div class="ads">
-    <!-- 468×60 ad -->
-    <ins class="adsbygoogle"
-         style="display:inline-block;width:468px;height:60px"
-         data-ad-client="ca-pub-4003447295960802"
-         data-ad-slot="YOUR_SLOT_ID"></ins>
-    <script async
-      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-    <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
-  </div>
-
-  <h2>Pro tips</h2>
-  <ul>
-    <li>Switch to a <strong>different accent</strong> for final proof—it forces fresh attention.</li>
-    <li>Record yourself reading <em>and</em> compare. Robot catch ⇾ human nuance.</li>
-    <li>Add a <strong>one-second pause after every “.</strong> to slow things just enough.</li>
-  </ul>
+  <section class="related">
+    <h3>Related guides</h3>
+    <ul>
+      <li><a href="../guides/tts-for-writers.html">TTS for Writers</a></li>
+      <li><a href="../guides/tts-voice-selection.html">Voice Selection</a></li>
+      <li><a href="../guides/tts-study-loop-templates.html">Proofreading sprint template</a></li>
+    </ul>
+  </section>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <div>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html">Voices</a>
+    <a href="../about.html">About</a>
+    <a href="../contact.html">Contact</a>
+    <a href="../privacy.html">Privacy</a>
+    <a href="../terms.html">Terms</a>
+    <a href="../privacy.html#controls">Privacy settings</a>
+    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="../sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Proofread safely in your browser.</div>
 </footer>
 </body>
 </html>

--- a/Uses/study.html
+++ b/Uses/study.html
@@ -24,19 +24,21 @@ section{margin-bottom:32px}
 .ads{margin:36px 0;text-align:center}
 .small{font-size:0.9em;color:#e0e0e0}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/Uses/study.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -59,7 +61,7 @@ section{margin-bottom:32px}
 
   <section>
     <h2><span class="number">2</span>Paste &amp; select a voice</h2>
-    <p>Return to the <a href="../index.html">home page</a>, paste your chunk into the box, then:</p>
+    <p>Return to the <a href="/index.html">home page</a>, paste your chunk into the box, then:</p>
     <ol>
       <li>Pick a <strong>language &amp; accent</strong> that feels natural (e.g. US-English Female).</li>
       <li>Set <strong>speed</strong> around 0.9× for heavy conceptual material; up to 1.3× for revision quick-runs.</li>
@@ -75,19 +77,6 @@ section{margin-bottom:32px}
       <li>Finish with a 1.5× speed skim of the whole chapter the night before your test.</li>
     </ul>
   </section>
-
-  <div class="ads">
-    <!-- responsive ad -->
-    <ins class="adsbygoogle"
-         style="display:block"
-         data-ad-client="ca-pub-4003447295960802"
-         data-ad-slot="YOUR_SLOT_ID"
-         data-ad-format="auto"
-         data-full-width-responsive="true"></ins>
-    <script async
-      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-    <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
-  </div>
 
   <section>
     <h2>FAQ for students</h2>
@@ -107,7 +96,7 @@ section{margin-bottom:32px}
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/Uses/study.html
+++ b/Uses/study.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-SVGML1VGPG');
+</script>
 <meta charset="utf-8">
 <title>Study Better With Text-to-Speech | Read-Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/about.html
+++ b/about.html
@@ -9,31 +9,30 @@
     gtag('js', new Date());
     gtag('config', 'G-SVGML1VGPG');
   </script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>About Read‑Aloud | Why It Exists and Where It’s Going</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Learn why Read‑Aloud was built, how it stays online, and what features are planned next for the browser-based text-to-speech tool." />
-  <link rel="canonical" href="https://www.read-aloud.com/about.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/about.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html" aria-current="page">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html" aria-current="page">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> About</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> About</div>
   <h1>About Read‑Aloud</h1>
   <p class="lead">Read‑Aloud is a privacy-first text-to-speech tool built to help people listen to the words they already have. Here is why it exists, how it is funded, and what is coming next.</p>
 
@@ -60,7 +59,7 @@
     <h2 style="margin-top:0">How it stays online</h2>
     <p>
       Read‑Aloud is free to use. Hosting and maintenance costs are covered by a mix of lightweight ads
-      on informational pages, small affiliate commissions from optional <a href="recommendations.html" rel="sponsored nofollow">reading accessories</a>, and voluntary tips from people who find the tool helpful. Ads are deliberately disabled on the <a href="app.html">Tool</a> itself to keep user-pasted text separate from ad code.
+      on informational pages, small affiliate commissions from optional <a href="/recommendations.html" rel="sponsored nofollow">reading accessories</a>, and voluntary tips from people who find the tool helpful. Ads are deliberately disabled on the <a href="/app.html">Tool</a> itself to keep user-pasted text separate from ad code.
     </p>
     <p>
       Operating costs include hosting the site, monitoring browser API changes, and testing across
@@ -80,20 +79,20 @@
       <li><strong>Session memory:</strong> Remembering your last speed and language per device so you can resume faster without storing text.</li>
       <li><strong>Improved mobile controls:</strong> Larger buttons and accessible spacing for one-handed playback on phones.</li>
       <li><strong>Inline highlighting:</strong> Optional word highlighting during playback for readers who like visual tracking.</li>
-      <li><strong>Guided checklists:</strong> Built-in presets based on the <a href="guides/tts-study-loop-templates.html">study loop templates</a> so students can start a timed listening sprint with one tap.</li>
+      <li><strong>Guided checklists:</strong> Built-in presets based on the <a href="/guides/tts-study-loop-templates.html">study loop templates</a> so students can start a timed listening sprint with one tap.</li>
       <li><strong>Voice notes:</strong> A short text note field beside the player so writers can mark sentences without switching tabs.</li>
     </ul>
     <p>
-      If you have a use case that is not covered here, let me know through the <a href="contact.html">Contact page</a>. Feedback from students, writers, and accessibility advocates directly shapes what ships next.
+      If you have a use case that is not covered here, let me know through the <a href="/contact.html">Contact page</a>. Feedback from students, writers, and accessibility advocates directly shapes what ships next.
     </p>
   </section>
 
   <section class="card">
     <h2 style="margin-top:0">How to follow updates</h2>
     <p>
-      Major changes are summarized on the <a href="guides.html">Guides</a> page and inside the tool’s
-      sidebar tips. When browsers roll out new speech features, I update the <a href="voices.html">Voice Gallery</a> and the
-      <a href="help.html">Help Center</a> with fresh screenshots and steps. If you rely on Read‑Aloud for coursework or client
+      Major changes are summarized on the <a href="/guides.html">Guides</a> page and inside the tool’s
+      sidebar tips. When browsers roll out new speech features, I update the <a href="/voices.html">Voice Gallery</a> and the
+      <a href="/help.html">Help Center</a> with fresh screenshots and steps. If you rely on Read‑Aloud for coursework or client
       work, bookmark those pages so you can skim what changed after each release.
     </p>
   </section>
@@ -101,18 +100,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html" aria-current="page">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html" aria-current="page">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Built to keep listening simple and private.</div>
 </footer>

--- a/about.html
+++ b/about.html
@@ -1,141 +1,120 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-<meta charset="utf-8">
-<title>About | Read‑Aloud</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="description" content="Read‑Aloud is a free, privacy‑first text‑to‑speech tool that reads your text out loud in your browser using your device’s voices.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-  main{max-width:980px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-  .highlight{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-  ul{padding-left:20px}
-  hr{margin:24px 0}
-</style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SVGML1VGPG');
+  </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>About Read‑Aloud | Why It Exists and Where It’s Going</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Learn why Read‑Aloud was built, how it stays online, and what features are planned next for the browser-based text-to-speech tool." />
+  <link rel="canonical" href="https://www.read-aloud.com/about.html">
+  <link rel="stylesheet" href="site.css">
 </head>
-
 <body>
 <header>
-  <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html" aria-current="page">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html" aria-current="page">About</a>
+    </nav>
+  </div>
 </header>
 
 <main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> About</div>
   <h1>About Read‑Aloud</h1>
-  <p class="small"><strong>Last updated:</strong> December 2025</p>
+  <p class="lead">Read‑Aloud is a privacy-first text-to-speech tool built to help people listen to the words they already have. Here is why it exists, how it is funded, and what is coming next.</p>
 
-  <p>
-    <strong>Read‑Aloud</strong> is an independent, hobby‑run project built to make text‑to‑speech simple:
-    paste text, choose a voice and speed, and press <strong>Start</strong>.
-    The goal is a distraction‑free tool you can open instantly—no accounts, no uploads, no complicated setup.
-  </p>
-
-  <div class="highlight">
-    <strong>One sentence summary:</strong> Read‑Aloud reads your text out loud in your browser using the voices already on your device.
-  </div>
-
-  <h2>What makes Read‑Aloud different</h2>
-  <ul>
-    <li><strong>Privacy-first by design:</strong> your pasted text is spoken by your browser/OS speech engine, not uploaded to our servers.</li>
-    <li><strong>Fast and lightweight:</strong> no login, no paywall, no “app install” required.</li>
-    <li><strong>Built for real use-cases:</strong> studying, proofreading, accessibility support, and language practice.</li>
-    <li><strong>Keyboard-friendly:</strong> we publish keyboard shortcuts and keep controls simple and clearly labeled.</li>
-  </ul>
-
-  <h2>How it works (Read‑Aloud specifics)</h2>
-  <div class="box">
-    <ul>
-      <li><strong>Voices come from your browser/OS.</strong> That means the voice list can differ on Chrome vs Safari vs Firefox—and it can differ by device.</li>
-      <li><strong>If a voice sounds robotic:</strong> try another voice, or try a different browser. (Desktop Chrome/Edge are often the most reliable.)</li>
-      <li><strong>Offline use:</strong> once the page loads, system voices often keep working without an internet connection. If your browser has no voices, the fallback offline voice may require an initial download first.</li>
-      <li><strong>iPhone/iPad note:</strong> iOS can be strict about audio playback. If you hear nothing or the voice list is empty, check the troubleshooting steps on the <a href="help.html">Help</a> page.</li>
-    </ul>
-    <p class="small">
-      Deep dive: <a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability</a>
+  <section class="card">
+    <h2 style="margin-top:0">Why this exists</h2>
+    <p>
+      Read‑Aloud started as a personal project to make browser-based speech less clunky. Many tools
+      required extensions, cloud logins, or copy-pasting into a separate desktop app. I wanted
+      something that opened in one tab, respected privacy, and worked across school laptops and locked
+      down work machines. The first version was a bare textarea with Start and Stop buttons. The
+      progress meter, keyboard shortcuts, and voice filters came later based on the problems users
+      were actually hitting.
     </p>
-  </div>
+    <p>
+      The mission is simple: let people listen to their own text without friction. That means using the
+      system voices they already trust, keeping pages lightweight for readers on slow networks, and
+      writing documentation that teaches practical workflows—not just marketing copy. The guides are
+      written with real use cases (students cramming, writers editing, readers with ADHD pacing their
+      day) so new visitors can immediately see where the tool fits in.
+    </p>
+  </section>
 
-  <h2>About MP3 downloads</h2>
-  <p>
-    Read‑Aloud currently supports <strong>browser playback</strong>. MP3 export is not enabled for system voices.
-    Exporting a reliable MP3 directly from browser text‑to‑speech is harder than it looks (and many approaches require sending text to a server).
-  </p>
-  <p class="small">
-    Details: <a href="guide-mp3-export.html">Why MP3 export is hard in browser TTS</a>
-  </p>
+  <section class="card">
+    <h2 style="margin-top:0">How it stays online</h2>
+    <p>
+      Read‑Aloud is free to use. Hosting and maintenance costs are covered by a mix of lightweight ads
+      on informational pages, small affiliate commissions from optional <a href="recommendations.html" rel="sponsored nofollow">reading accessories</a>, and voluntary tips from people who find the tool helpful. Ads are deliberately disabled on the <a href="app.html">Tool</a> itself to keep user-pasted text separate from ad code.
+    </p>
+    <p>
+      Operating costs include hosting the site, monitoring browser API changes, and testing across
+      multiple devices. When costs exceed monthly donations, I cover the difference so the experience
+      stays stable. If you want to support the project, sharing the guides with classmates or
+      colleagues is just as valuable as financial support—it helps reach the people who need the tool
+      most.
+    </p>
+  </section>
 
-  <h2>Privacy and data</h2>
-  <p>
-    Read‑Aloud is designed so that the text you paste stays on your device while speech is generated.
-    For the full details (including any third‑party services such as analytics or ads, if enabled),
-    see the <a href="privacy.html">Privacy Policy</a>.
-  </p>
+  <section class="card">
+    <h2 style="margin-top:0">Roadmap and planned features</h2>
+    <p>
+      The roadmap focuses on clarity, speed, and privacy. Here is what is actively being explored:
+    </p>
+    <ul>
+      <li><strong>Session memory:</strong> Remembering your last speed and language per device so you can resume faster without storing text.</li>
+      <li><strong>Improved mobile controls:</strong> Larger buttons and accessible spacing for one-handed playback on phones.</li>
+      <li><strong>Inline highlighting:</strong> Optional word highlighting during playback for readers who like visual tracking.</li>
+      <li><strong>Guided checklists:</strong> Built-in presets based on the <a href="guides/tts-study-loop-templates.html">study loop templates</a> so students can start a timed listening sprint with one tap.</li>
+      <li><strong>Voice notes:</strong> A short text note field beside the player so writers can mark sentences without switching tabs.</li>
+    </ul>
+    <p>
+      If you have a use case that is not covered here, let me know through the <a href="contact.html">Contact page</a>. Feedback from students, writers, and accessibility advocates directly shapes what ships next.
+    </p>
+  </section>
 
-  <h2>How this site stays online</h2>
-  <p>
-    Read‑Aloud is kept online through a combination of:
-  </p>
-  <ul>
-    <li><strong>Optional support:</strong> a small donation link (“Buy me a coffee”).</li>
-    <li><strong>Clearly marked recommendations:</strong> when we recommend assistive tools, purchases may support the site at no extra cost to you.</li>
-    <li><strong>Small, clearly labeled ads (optional):</strong> if ads are enabled in the future, they will be clearly marked and kept lightweight.</li>
-  </ul>
-
-  <div class="highlight">
-    If you’d like to say thanks, you can <a href="https://coff.ee/readaloud" target="_blank" rel="noopener">buy me a coffee</a>.
-    Sharing the tool with someone who needs it also helps a lot.
-  </div>
-
-  <h2>Who runs the site?</h2>
-  <p>
-    Hi! I’m Nick. I maintain the codebase, handle support email, and keep the site running.
-    Read‑Aloud is a spare‑time project, so bug reports and specific feature requests are genuinely helpful.
-  </p>
-
-  <h2>Credits</h2>
-  <ul>
-    <li><strong>Web Speech API</strong> — provided by browser vendors</li>
-    <li><strong>meSpeak.js</strong> — open-source fallback voice engine</li>
-    <li><strong>Background texture</strong> — public domain texture source</li>
-  </ul>
-
-  <hr>
-  <p class="small">
-    Next: <a href="guides.html">Guides</a> ·
-    <a href="help.html">Help</a> ·
-    <a href="contact.html">Contact</a> ·
-    <a href="terms.html">Terms</a>
-  </p>
+  <section class="card">
+    <h2 style="margin-top:0">How to follow updates</h2>
+    <p>
+      Major changes are summarized on the <a href="guides.html">Guides</a> page and inside the tool’s
+      sidebar tips. When browsers roll out new speech features, I update the <a href="voices.html">Voice Gallery</a> and the
+      <a href="help.html">Help Center</a> with fresh screenshots and steps. If you rely on Read‑Aloud for coursework or client
+      work, bookmark those pages so you can skim what changed after each release.
+    </p>
+  </section>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html">Tool</a>
+    <a href="guides.html">Guides</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
+    <a href="about.html" aria-current="page">About</a>
+    <a href="contact.html">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Built to keep listening simple and private.</div>
 </footer>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -14,8 +14,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
   <title>Use the Read‑Aloud Tool | Browser Text-to-Speech</title>
   <meta name="description" content="Open the Read‑Aloud text-to-speech tool. Paste text, pick a voice, adjust speed, and listen privately using the system voices already on your device." />
-  <link rel="canonical" href="https://www.read-aloud.com/app">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/app">
+  <link rel="stylesheet" href="/site.css">
   <style>
     .tool-shell { background: #fff; border: 1px solid #d7deea; border-radius: 16px; padding: 18px; box-shadow: var(--shadow); }
     textarea#txt { width: 100%; min-height: 180px; padding: 12px; border: 1px solid #cfd8e3; border-radius: 12px; background: #f9fbff; }
@@ -35,18 +35,18 @@
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html" aria-current="page">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html" aria-current="page">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Tool</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Tool</div>
   <h1>Read‑Aloud Tool</h1>
   <p class="lead">Paste text you own, choose a voice, and start listening. The controls below run entirely in your browser using system voices.</p>
 
@@ -100,10 +100,10 @@
       </p>
       <p>
         Need guidance on choosing the right voice or pacing? See
-        <a href="guides/tts-voice-selection.html">How to Choose the Best Voice</a> and the
-        <a href="guides/tts-for-students.html">student workflow guide</a>. If audio stops mid-way,
+        <a href="/guides/tts-voice-selection.html">How to Choose the Best Voice</a> and the
+        <a href="/guides/tts-for-students.html">student workflow guide</a>. If audio stops mid-way,
         reduce the amount of text, lower the speed slider slightly, and try again before sending a
-        report via the <a href="contact.html">Contact page</a>.
+        report via the <a href="/contact.html">Contact page</a>.
       </p>
     </div>
   </div>
@@ -111,18 +111,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html" aria-current="page">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html" aria-current="page">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Ads are intentionally disabled on this tool page to keep user text separate from ad code.</div>
 </footer>

--- a/app.html
+++ b/app.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SVGML1VGPG');
+  </script>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
+  <title>Use the Read‑Aloud Tool | Browser Text-to-Speech</title>
+  <meta name="description" content="Open the Read‑Aloud text-to-speech tool. Paste text, pick a voice, adjust speed, and listen privately using the system voices already on your device." />
+  <link rel="canonical" href="https://www.read-aloud.com/app">
+  <link rel="stylesheet" href="site.css">
+  <style>
+    .tool-shell { background: #fff; border: 1px solid #d7deea; border-radius: 16px; padding: 18px; box-shadow: var(--shadow); }
+    textarea#txt { width: 100%; min-height: 180px; padding: 12px; border: 1px solid #cfd8e3; border-radius: 12px; background: #f9fbff; }
+    label { font-weight: 600; margin-right: 12px; display: inline-block; margin-top: 10px; }
+    select, input[type="range"] { margin-top: 6px; }
+    .control-row { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-top: 10px; }
+    .btn { background: var(--accent); color: #fff; border: none; padding: 10px 14px; border-radius: 10px; cursor: pointer; }
+    .btn:hover { background: #0b3a86; }
+    progress { width: 100%; height: 16px; }
+    #meter { margin-top: 8px; font-weight: 600; color: #0f4aad; }
+    .tip { background: #f5f7fb; border: 1px solid #d7deea; border-radius: 12px; padding: 12px 14px; }
+    kbd { background: #eef3fc; border: 1px solid #d3ddec; border-radius: 6px; padding: 3px 6px; }
+  </style>
+</head>
+<body>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html" aria-current="page">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Tool</div>
+  <h1>Read‑Aloud Tool</h1>
+  <p class="lead">Paste text you own, choose a voice, and start listening. The controls below run entirely in your browser using system voices.</p>
+
+  <div class="app-grid">
+    <div class="tool-shell">
+      <label for="txt">Your text</label>
+      <textarea id="txt" placeholder="Paste or type text here…"></textarea>
+
+      <div class="control-row">
+        <label for="lang">Language
+          <select id="lang"></select>
+        </label>
+        <label for="voice">Voice
+          <select id="voice"><option value="-1">Default</option></select>
+        </label>
+        <label for="rate">Speed <span id="rv">1</span>x
+          <input type="range" id="rate" min="0.5" max="2" step="0.1" value="1">
+        </label>
+      </div>
+
+      <div class="control-row">
+        <button id="start" class="btn">Start</button>
+        <button id="pause" class="btn">Pause</button>
+        <button id="resume" class="btn">Resume</button>
+        <button id="stop" class="btn">Stop</button>
+      </div>
+
+      <progress id="bar" value="0" max="100"></progress>
+      <div id="meter"><strong>0 %</strong> — <span id="ela">00:00:00</span> | <span id="rem">00:00:00</span></div>
+      <div id="disp" aria-live="polite" class="small" style="margin-top:6px"></div>
+    </div>
+
+    <div class="card">
+      <h2 style="margin-top:0">Quick tips before you start</h2>
+      <p>
+        Keep your paste under a few thousand characters for the smoothest playback. If the voice list
+        looks empty, reload the page after unlocking your device audio or switch to a modern browser
+        like Chrome, Edge, or Safari. Tap Start once to give the tab audio permission; after that,
+        the keyboard shortcuts below will work consistently.
+      </p>
+      <div class="tip">
+        <strong>Keyboard shortcuts:</strong><br>
+        Start <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> · Pause <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> ·
+        Resume <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> · Stop <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> ·
+        Focus text box <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Y</kbd>.
+      </div>
+      <p>
+        Respect copyright and privacy: only paste text you have permission to use, and avoid copying
+        documents that include regulated data. Read‑Aloud does not upload your text, but you should
+        still avoid sharing confidential contracts, patient details, or sensitive student records.
+      </p>
+      <p>
+        Need guidance on choosing the right voice or pacing? See
+        <a href="guides/tts-voice-selection.html">How to Choose the Best Voice</a> and the
+        <a href="guides/tts-for-students.html">student workflow guide</a>. If audio stops mid-way,
+        reduce the amount of text, lower the speed slider slightly, and try again before sending a
+        report via the <a href="contact.html">Contact page</a>.
+      </p>
+    </div>
+  </div>
+</main>
+
+<footer>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html" aria-current="page">Tool</a>
+    <a href="guides.html">Guides</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
+    <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Ads are intentionally disabled on this tool page to keep user text separate from ad code.</div>
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/mespeak@2.0.2/mespeak.min.js"></script>
+<script>
+mespeak.loadConfig("https://cdn.jsdelivr.net/npm/mespeak@2.0.2/mespeak_config.json");
+mespeak.loadVoice("https://cdn.jsdelivr.net/npm/mespeak@2.0.2/voices/en/en.json");
+</script>
+<script src="readaloud.js"></script>
+</body>
+</html>

--- a/audio.html
+++ b/audio.html
@@ -1,50 +1,84 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Audio Stream</title>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Audio Samples &amp; Streams | Read‑Aloud</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Listen to a sample audio stream and learn how Read‑Aloud handles live playback using local system voices." />
+  <link rel="canonical" href="https://www.read-aloud.com/audio.html">
+  <link rel="stylesheet" href="site.css">
 </head>
 <body>
 <header>
-  <nav id="mainNav">
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Audio</div>
+  <h1>Audio Samples &amp; Streams</h1>
+  <p class="lead">Want to check your speakers before using the tool? Play the sample stream below and then switch to the in-browser player when you are ready.</p>
+
+  <section class="card">
+    <h2>Sample stream</h2>
+    <p>This embedded stream helps you confirm your device volume before starting a Read‑Aloud session.</p>
+    <iframe src="https://tunein.com/embed/player/s23713/" style="width:100%; height:120px;" scrolling="no" frameborder="no" title="Sample audio stream"></iframe>
+    <p class="small">If the stream is blocked on a managed network, try connecting through a personal hotspot or skip straight to the player.</p>
+  </section>
+
+  <section class="card">
+    <h2>After the sound check</h2>
+    <p>
+      Once you know your speakers or headphones are working, open the <a href="app.html">Read‑Aloud tool</a>
+      and paste your text. The player uses system voices instead of this stream, so volume and tone may
+      differ. Adjust your preferred voice and speed inside the player.
+    </p>
+    <p class="small">If you hear the stream but not the player, reload the page to trigger the browser’s audio permission prompt.</p>
+  </section>
+
+  <section class="card">
+    <h2>Why we keep audio local</h2>
+    <p>
+      The stream above is just a test. The text-to-speech player relies on voices installed on your device
+      and does not send your text to a server. If you have trouble hearing the stream or the player, visit
+      the <a href="help.html">Help Center</a> for device-specific fixes.
+    </p>
+    <p>
+      Testing with a neutral stream also helps you rule out Bluetooth hiccups or system mute toggles
+      before you paste important text. If the stream works but Read‑Aloud is silent, switch voices or
+      browsers using the checklists in the Help Center to reload the device speech engine.
+    </p>
+  </section>
+</main>
+
+<footer>
+  <div>
     <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
+    <a href="app.html">Tool</a>
     <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
     <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
     <a href="privacy.html">Privacy</a>
     <a href="terms.html">Terms</a>
-  </nav>
-</header>
-  <h1>Embedded Audio Stream</h1>
-  <p>Listen to the station below:</p>
-
-  <!-- TuneIn IFRAME -->
-  <iframe 
-    src="https://tunein.com/embed/player/s23713/" 
-    style="width:100%; height:100px;" 
-    scrolling="no" 
-    frameborder="no">
-  </iframe>
-
-  <!-- Link to go back to your homepage -->
-  <p><a href="index.html">Back to Home</a></p>
-
-  <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Test audio, then enjoy local voices.</div>
 </footer>
 </body>
 </html>

--- a/audio.html
+++ b/audio.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Audio Samples &amp; Streams | Read‑Aloud</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Listen to a sample audio stream and learn how Read‑Aloud handles live playback using local system voices." />
-  <link rel="canonical" href="https://www.read-aloud.com/audio.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/audio.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Audio</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Audio</div>
   <h1>Audio Samples &amp; Streams</h1>
   <p class="lead">Want to check your speakers before using the tool? Play the sample stream below and then switch to the in-browser player when you are ready.</p>
 
@@ -41,7 +40,7 @@
   <section class="card">
     <h2>After the sound check</h2>
     <p>
-      Once you know your speakers or headphones are working, open the <a href="app.html">Read‑Aloud tool</a>
+      Once you know your speakers or headphones are working, open the <a href="/app.html">Read‑Aloud tool</a>
       and paste your text. The player uses system voices instead of this stream, so volume and tone may
       differ. Adjust your preferred voice and speed inside the player.
     </p>
@@ -53,7 +52,7 @@
     <p>
       The stream above is just a test. The text-to-speech player relies on voices installed on your device
       and does not send your text to a server. If you have trouble hearing the stream or the player, visit
-      the <a href="help.html">Help Center</a> for device-specific fixes.
+      the <a href="/help.html">Help Center</a> for device-specific fixes.
     </p>
     <p>
       Testing with a neutral stream also helps you rule out Bluetooth hiccups or system mute toggles
@@ -65,18 +64,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Test audio, then enjoy local voices.</div>
 </footer>

--- a/benefits.html
+++ b/benefits.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Benefits of Read‑Aloud | Why Use Browser-Based TTS</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Key benefits of Read‑Aloud: faster comprehension, hands-free review, accessibility, and privacy. Learn how the browser-based tool helps different readers." />
-  <link rel="canonical" href="https://www.read-aloud.com/benefits.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/benefits.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Benefits</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Benefits</div>
   <h1>Benefits of Read‑Aloud</h1>
   <p class="lead">Browser-based text-to-speech removes friction for students, writers, and anyone who needs to hear their words. Here is what you gain by using Read‑Aloud.</p>
 
@@ -45,7 +44,7 @@
     <h2>Hands-free review when you need it</h2>
     <p>
       Because everything runs in the browser, you can prop up a laptop or phone and listen while
-      stretching, organizing flashcards, or commuting. The <a href="app.html">tool</a> works offline once
+      stretching, organizing flashcards, or commuting. The <a href="/app.html">tool</a> works offline once
       loaded, and keyboard shortcuts make it easy to pause or resume without grabbing the mouse.
     </p>
   </section>
@@ -63,7 +62,7 @@
     <h2>Support for different learning styles</h2>
     <p>
       The tool pairs well with dual reading, focus timers, and proofreading by ear. Explore the
-      <a href="guides.html">guides library</a> to see workflows for ADHD, dyslexia, language practice,
+      <a href="/guides.html">guides library</a> to see workflows for ADHD, dyslexia, language practice,
       and writing. Each guide shows how to combine Read‑Aloud with simple checklists so you can get value
       without new software.
     </p>
@@ -72,18 +71,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Built for focus and accessibility.</div>
 </footer>

--- a/benefits.html
+++ b/benefits.html
@@ -1,62 +1,91 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>Benefits | Read-Aloud</title>
-  <meta name="description" content="Discover the key benefits of using our free text-to-speech reader, including accessibility, productivity, and learning enhancements.">
-  <link rel="stylesheet" href="styles.css">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Benefits of Read‑Aloud | Why Use Browser-Based TTS</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Key benefits of Read‑Aloud: faster comprehension, hands-free review, accessibility, and privacy. Learn how the browser-based tool helps different readers." />
+  <link rel="canonical" href="https://www.read-aloud.com/benefits.html">
+  <link rel="stylesheet" href="site.css">
 </head>
 <body>
-  <!-- HEADER -->
-  <header>
-  <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
 </header>
 
-  <!-- MAIN CONTENT: Benefits Section -->
-  <main>
-    <section id="benefits">
-      <div class="container">
-        <h2>Why Use Our Tool?</h2>
-        <div class="benefit">
-          <h3>Accessibility</h3>
-          <p>Listen to text if you have visual impairments or dyslexia. Our tool aims to break down barriers by providing voice options in multiple languages.</p>
-        </div>
-        <div class="benefit">
-          <h3>Productivity</h3>
-          <p>Convert emails, articles, and reports to audio on the go. Stay efficient by “reading” even when your eyes are busy.</p>
-        </div>
-        <div class="benefit">
-          <h3>Learning</h3>
-          <p>Enhance your studies by listening to your notes or foreign language texts. Hearing text can improve comprehension and retention.</p>
-        </div>
-      </div>
-    </section>
-  </main>
+<main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Benefits</div>
+  <h1>Benefits of Read‑Aloud</h1>
+  <p class="lead">Browser-based text-to-speech removes friction for students, writers, and anyone who needs to hear their words. Here is what you gain by using Read‑Aloud.</p>
 
-  <!-- FOOTER -->
-  <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <section class="card">
+    <h2>Better comprehension in less time</h2>
+    <p>
+      Listening forces you to process sentences at a steady pace. With Read‑Aloud you can keep the
+      progress meter visible, pause to take notes, and resume without losing place. Many students report
+      they retain more from a 15-minute listen than from 30 minutes of silent skimming because audio
+      keeps wandering eyes in check.
+    </p>
+  </section>
+
+  <section class="card">
+    <h2>Hands-free review when you need it</h2>
+    <p>
+      Because everything runs in the browser, you can prop up a laptop or phone and listen while
+      stretching, organizing flashcards, or commuting. The <a href="app.html">tool</a> works offline once
+      loaded, and keyboard shortcuts make it easy to pause or resume without grabbing the mouse.
+    </p>
+  </section>
+
+  <section class="card">
+    <h2>Accessibility without extra logins</h2>
+    <p>
+      Read‑Aloud uses system voices already on your device, so there is no account to manage and no cloud
+      upload. That keeps the experience compliant with many classroom and workplace privacy policies.
+      You can still customize pacing, language, and voice quality without installing extensions.
+    </p>
+  </section>
+
+  <section class="card">
+    <h2>Support for different learning styles</h2>
+    <p>
+      The tool pairs well with dual reading, focus timers, and proofreading by ear. Explore the
+      <a href="guides.html">guides library</a> to see workflows for ADHD, dyslexia, language practice,
+      and writing. Each guide shows how to combine Read‑Aloud with simple checklists so you can get value
+      without new software.
+    </p>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html">Tool</a>
+    <a href="guides.html">Guides</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
+    <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Built for focus and accessibility.</div>
 </footer>
 </body>
 </html>

--- a/benifits.html
+++ b/benifits.html
@@ -3,67 +3,67 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Benefits of Read‑Aloud (Yes, You Spelled It Right)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Quick overview of why Read‑Aloud helps readers and writers. Learn how the browser-based tool improves focus, accessibility, and privacy." />
-  <link rel="canonical" href="https://www.read-aloud.com/benefits.html">
-  <link rel="stylesheet" href="site.css">
+  <meta name="robots" content="noindex,follow">
+  <link rel="canonical" href="https://read-aloud.com/benefits.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Benefits</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Benefits</div>
   <h1>Benefits of Read‑Aloud</h1>
   <p class="lead">If you landed here while typing “benifits,” you are in the right place. Here is a concise rundown of what Read‑Aloud offers.</p>
   <ul class="card">
     <li><strong>Focus without friction:</strong> Paste text and listen immediately—no logins or extensions required.</li>
     <li><strong>Accessible by default:</strong> Uses the voices already on your device, keeping your text local and private.</li>
-    <li><strong>Great for studying:</strong> Combine the player with the <a href="guides/tts-for-students.html">student workflow guide</a> to build reliable listening sessions.</li>
-    <li><strong>Helpful for writers:</strong> Proofread drafts by ear using tips from the <a href="guides/tts-for-writers.html">writer’s guide</a>.</li>
-    <li><strong>Easy voice tuning:</strong> Visit the <a href="voices.html">Voice Gallery</a> to add languages or accents that fit your work.</li>
+    <li><strong>Great for studying:</strong> Combine the player with the <a href="/guides/tts-for-students.html">student workflow guide</a> to build reliable listening sessions.</li>
+    <li><strong>Helpful for writers:</strong> Proofread drafts by ear using tips from the <a href="/guides/tts-for-writers.html">writer’s guide</a>.</li>
+    <li><strong>Easy voice tuning:</strong> Visit the <a href="/voices.html">Voice Gallery</a> to add languages or accents that fit your work.</li>
   </ul>
   <p>
     If you are browsing on a phone, save the tool to your home screen using the instructions in the
     <a href="bookmark.html">bookmark guide</a>. The saved shortcut remembers your preferred voice and gets
     you listening faster during class or meetings.
   </p>
-  <p>For a deeper explanation, read the full <a href="benefits.html">Benefits page</a> or head straight to the <a href="app.html">tool</a> to start listening.</p>
-  <p class="small">Need troubleshooting? The <a href="help.html">Help Center</a> covers common fixes like empty voice lists and offline behavior.</p>
+  <p>For a deeper explanation, read the full <a href="benefits.html">Benefits page</a> or head straight to the <a href="/app.html">tool</a> to start listening.</p>
+  <p class="small">Need troubleshooting? The <a href="/help.html">Help Center</a> covers common fixes like empty voice lists and offline behavior.</p>
   <p class="small">You can also explore the <a href="blog.html">Product Updates</a> page to see what changed recently.</p>
   <p class="small">When in doubt, head to the <a href="help.html#faq">FAQ section</a> for quick answers.</p>
-  <p class="small">For accessibility accommodations, the <a href="guides/tts-for-dyslexia-support.html">dyslexia guide</a> shows pacing and tracking tips.</p>
+  <p class="small">For accessibility accommodations, the <a href="/guides/tts-for-dyslexia-support.html">dyslexia guide</a> shows pacing and tracking tips.</p>
   <p class="small">Need to compare devices? The <a href="help.html#offline">offline tips</a> cover how laptops and phones behave differently.</p>
 </main>
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Spelling aside, the benefits are the same.</div>
 </footer>

--- a/benifits.html
+++ b/benifits.html
@@ -1,62 +1,71 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>Benefits | Read-Aloud</title>
-  <meta name="description" content="Discover the key benefits of using our free text-to-speech reader, including accessibility, productivity, and learning enhancements.">
-  <link rel="stylesheet" href="styles.css">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Benefits of Read‑Aloud (Yes, You Spelled It Right)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Quick overview of why Read‑Aloud helps readers and writers. Learn how the browser-based tool improves focus, accessibility, and privacy." />
+  <link rel="canonical" href="https://www.read-aloud.com/benefits.html">
+  <link rel="stylesheet" href="site.css">
 </head>
 <body>
-  <!-- HEADER -->
-  <header>
-  <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
 </header>
 
-  <!-- MAIN CONTENT: Benefits Section -->
-  <main>
-    <section id="benefits">
-      <div class="container">
-        <h2>Why Use Our Tool?</h2>
-        <div class="benefit">
-          <h3>Accessibility</h3>
-          <p>Listen to text if you have visual impairments or dyslexia. Our tool aims to break down barriers by providing voice options in multiple languages.</p>
-        </div>
-        <div class="benefit">
-          <h3>Productivity</h3>
-          <p>Convert emails, articles, and reports to audio on the go. Stay efficient by “reading” even when your eyes are busy.</p>
-        </div>
-        <div class="benefit">
-          <h3>Learning</h3>
-          <p>Enhance your studies by listening to your notes or foreign language texts. Hearing text can improve comprehension and retention.</p>
-        </div>
-      </div>
-    </section>
-  </main>
+<main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Benefits</div>
+  <h1>Benefits of Read‑Aloud</h1>
+  <p class="lead">If you landed here while typing “benifits,” you are in the right place. Here is a concise rundown of what Read‑Aloud offers.</p>
+  <ul class="card">
+    <li><strong>Focus without friction:</strong> Paste text and listen immediately—no logins or extensions required.</li>
+    <li><strong>Accessible by default:</strong> Uses the voices already on your device, keeping your text local and private.</li>
+    <li><strong>Great for studying:</strong> Combine the player with the <a href="guides/tts-for-students.html">student workflow guide</a> to build reliable listening sessions.</li>
+    <li><strong>Helpful for writers:</strong> Proofread drafts by ear using tips from the <a href="guides/tts-for-writers.html">writer’s guide</a>.</li>
+    <li><strong>Easy voice tuning:</strong> Visit the <a href="voices.html">Voice Gallery</a> to add languages or accents that fit your work.</li>
+  </ul>
+  <p>
+    If you are browsing on a phone, save the tool to your home screen using the instructions in the
+    <a href="bookmark.html">bookmark guide</a>. The saved shortcut remembers your preferred voice and gets
+    you listening faster during class or meetings.
+  </p>
+  <p>For a deeper explanation, read the full <a href="benefits.html">Benefits page</a> or head straight to the <a href="app.html">tool</a> to start listening.</p>
+  <p class="small">Need troubleshooting? The <a href="help.html">Help Center</a> covers common fixes like empty voice lists and offline behavior.</p>
+  <p class="small">You can also explore the <a href="blog.html">Product Updates</a> page to see what changed recently.</p>
+  <p class="small">When in doubt, head to the <a href="help.html#faq">FAQ section</a> for quick answers.</p>
+  <p class="small">For accessibility accommodations, the <a href="guides/tts-for-dyslexia-support.html">dyslexia guide</a> shows pacing and tracking tips.</p>
+  <p class="small">Need to compare devices? The <a href="help.html#offline">offline tips</a> cover how laptops and phones behave differently.</p>
+</main>
 
-  <!-- FOOTER -->
-  <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+<footer>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html">Tool</a>
+    <a href="guides.html">Guides</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
+    <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Spelling aside, the benefits are the same.</div>
 </footer>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Product Updates | Read‑Aloud</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Recent changes to Read‑Aloud: new guides, landing page improvements, and privacy-first updates." />
-  <link rel="canonical" href="https://www.read-aloud.com/blog.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/blog.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Updates</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Updates</div>
   <h1>Product Updates</h1>
   <p class="lead">A quick log of what changed recently. This page highlights improvements so reviewers and returning users can see that Read‑Aloud is actively maintained.</p>
 
@@ -35,7 +34,7 @@
     <h2>February 2025: Content-first relaunch</h2>
     <p>
       The homepage now explains who Read‑Aloud is for, how it works, and how privacy is handled. We also
-      moved the tool to <a href="app.html">/app</a> so ads stay away from user-pasted text. Navigation now
+      moved the tool to <a href="/app.html">/app</a> so ads stay away from user-pasted text. Navigation now
       includes Guides, Help, Voices, and About for easier discovery.
     </p>
   </section>
@@ -61,8 +60,8 @@
     <h2>Upcoming</h2>
     <p>
       Planned updates include session memory for preferred speed/voice, improved mobile controls, and an
-      optional highlight mode while listening. Follow the <a href="about.html">About page</a> for roadmap
-      notes or <a href="contact.html">contact us</a> with suggestions.
+      optional highlight mode while listening. Follow the <a href="/about.html">About page</a> for roadmap
+      notes or <a href="/contact.html">contact us</a> with suggestions.
     </p>
     <p>
       We also review feedback each month to tune the guides. If a section feels unclear or you want a
@@ -74,18 +73,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Last updated February 2025.</div>
 </footer>

--- a/blog.html
+++ b/blog.html
@@ -1,70 +1,93 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>Blog | Read-Aloud</title>
-  <meta name="description" content="Explore our blog to learn how text-to-speech (TTS) technology improves productivity, accessibility, and more.">
-  <link rel="stylesheet" href="styles.css">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Product Updates | Read‑Aloud</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Recent changes to Read‑Aloud: new guides, landing page improvements, and privacy-first updates." />
+  <link rel="canonical" href="https://www.read-aloud.com/blog.html">
+  <link rel="stylesheet" href="site.css">
 </head>
 <body>
-  <!-- HEADER -->
-  <header>
-  <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
 </header>
 
-  <!-- MAIN CONTENT: Blog Posts -->
-  <main>
-    <section id="blog">
-      <div class="container">
-        <h2>Blog & Resources</h2>
+<main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Updates</div>
+  <h1>Product Updates</h1>
+  <p class="lead">A quick log of what changed recently. This page highlights improvements so reviewers and returning users can see that Read‑Aloud is actively maintained.</p>
 
-        <article>
-          <h3>How TTS Can Improve Your Productivity</h3>
-          <p>
-            Ever wish you could “read” an article while on the go? Text-to-speech makes it simple. Whether you’re commuting, doing household chores, or juggling tasks at work, TTS can help you absorb information hands-free.
-          </p>
-          <p>
-            For students, TTS can transform e-books or PDF notes into audio format, promoting better retention. For professionals, it’s a great way to stay on top of reports and memos when you don’t have time to sit down and read.
-          </p>
-        </article>
+  <section class="card">
+    <h2>February 2025: Content-first relaunch</h2>
+    <p>
+      The homepage now explains who Read‑Aloud is for, how it works, and how privacy is handled. We also
+      moved the tool to <a href="app.html">/app</a> so ads stay away from user-pasted text. Navigation now
+      includes Guides, Help, Voices, and About for easier discovery.
+    </p>
+  </section>
 
-        <article>
-          <h3>Accessibility: Empowering More Users</h3>
-          <p>
-            TTS is vital for many people with visual impairments or reading difficulties. By providing clear, synthesized speech, our tool ensures that no one is left out from accessing digital content. Combined with our user-friendly interface, it’s an all-in-one solution for inclusive reading.
-          </p>
-          <p>
-            Check out our <a href="benefits.html">Benefits/Use-Cases</a> section for more details. If you have questions about accessibility settings, feel free to <a href="contact.html">contact us</a> or consult our <a href="faq.html">FAQ</a>.
-          </p>
-        </article>
-      </div>
-    </section>
-  </main>
+  <section class="card">
+    <h2>Guide library expansion</h2>
+    <p>
+      Eight new long-form guides now cover studying, writing, accessibility, language shadowing, voice
+      selection, and privacy habits. Each guide includes breadcrumbs, related links, and meta
+      descriptions to make navigation clearer and improve crawlability.</p>
+  </section>
 
-  <!-- FOOTER -->
-  <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <section class="card">
+    <h2>Help Center and Voices page</h2>
+    <p>
+      The Help Center now documents iPhone/iPad audio fixes, missing voice steps, offline behavior, and
+      long-text performance tips. The Voice Gallery explains why voice lists differ by OS and how to add
+      more voices on macOS, Windows, iOS, and Android.
+    </p>
+  </section>
+
+  <section class="card">
+    <h2>Upcoming</h2>
+    <p>
+      Planned updates include session memory for preferred speed/voice, improved mobile controls, and an
+      optional highlight mode while listening. Follow the <a href="about.html">About page</a> for roadmap
+      notes or <a href="contact.html">contact us</a> with suggestions.
+    </p>
+    <p>
+      We also review feedback each month to tune the guides. If a section feels unclear or you want a
+      screenshot of a specific device, mention it when you write in. The goal is to keep documentation as
+      practical as the tool itself.
+    </p>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html">Tool</a>
+    <a href="guides.html">Guides</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
+    <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Last updated February 2025.</div>
 </footer>
 </body>
 </html>

--- a/bookmark.html
+++ b/bookmark.html
@@ -1,397 +1,93 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Text-to-Speech Website</title>
-    <style>
-        /* General styling for the page */
-        body {
-            font-family: Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            text-align: center;
-            padding-bottom: 50px;
-            background: linear-gradient(to bottom, #f8f9fa, #e9ecef);
-            min-height: 100vh;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-        }
-
-        /* Heading styling */
-        h1 {
-            margin-bottom: 20px;
-        }
-
-        /* Input area styling for the text box */
-        #textInput {
-            width: 80%;
-            height: 150px;
-            margin: 10px auto;
-            padding: 10px;
-            font-size: 16px;
-            border: 2px solid #6c757d;
-            border-radius: 5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            resize: none;
-        }
-
-        /* Display area styling for processed text */
-        #textDisplay {
-            width: 80%;
-            margin: 10px auto;
-            padding: 10px;
-            font-size: 16px;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-            min-height: 150px;
-            text-align: left;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-            display: none;
-            cursor: pointer;
-            background: #fff;
-        }
-
-        /* Button container and button styles */
-        .button-container {
-            display: flex;
-            justify-content: center;
-            gap: 15px;
-            margin-top: 15px;
-        }
-
-        button {
-            font-size: 16px;
-            padding: 10px 20px;
-            cursor: pointer;
-            border: none;
-            border-radius: 5px;
-            background: #007bff;
-            color: white;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            transition: background 0.3s;
-        }
-
-        /* Hover effect for buttons */
-        button:hover {
-            background: #0056b3;
-        }
-
-        /* Styling for dropdown selectors */
-        select {
-            font-size: 16px;
-            padding: 5px;
-            margin: 10px;
-            border: 2px solid #6c757d;
-            border-radius: 5px;
-            background: #fff;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        }
-
-        /* Bold labels for dropdowns */
-        label {
-            font-weight: bold;
-        }
-
-        /* Highlight styling for the current word being read */
-        .highlight {
-            background-color: yellow;
-        }
-
-        /* Styling for the progress container at the bottom of the page */
-        #progressContainer {
-            position: fixed;
-            bottom: 10px;
-            right: 10px;
-            background: #f8f9fa;
-            padding: 10px;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            text-align: left;
-            z-index: 1000;
-        }
-
-        /* Responsive design for smaller screens */
-        @media (max-width: 768px) {
-            #textInput, #textDisplay {
-                width: 90%;
-            }
-
-            button {
-                font-size: 14px;
-                padding: 8px 15px;
-            }
-
-            .button-container {
-                flex-direction: column;
-                gap: 10px;
-            }
-        }
-
-        .small {
-            font-size: 0.9em;
-            color: #444;
-        }
-    </style>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Bookmark Read‑Aloud | Quick Access Instructions</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="How to bookmark the Read‑Aloud tool on desktop and mobile so you can launch text-to-speech in one tap." />
+  <link rel="canonical" href="https://www.read-aloud.com/bookmark.html">
+  <link rel="stylesheet" href="site.css">
 </head>
 <body>
 <header>
-  <nav id="mainNav">
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Bookmark</div>
+  <h1>Bookmark Read‑Aloud</h1>
+  <p class="lead">Save the tool so you can launch it with one tap. These steps keep the experience fast on laptops, tablets, and phones.</p>
+
+  <section class="card">
+    <h2>Desktop (Chrome, Edge, Firefox)</h2>
+    <ul>
+      <li>Open <a href="app.html">read-aloud.com/app</a>.</li>
+      <li>Press <kbd>Ctrl</kbd>+<kbd>D</kbd> (Windows) or <kbd>Cmd</kbd>+<kbd>D</kbd> (macOS).</li>
+      <li>Choose the Bookmarks Bar and click Save. Drag it to the left for quicker access.</li>
+    </ul>
+    <p>Pin the tab if you keep the tool open all day. Right-click the tab and choose <em>Pin</em>.</p>
+  </section>
+
+  <section class="card">
+    <h2>iPhone or iPad</h2>
+    <ul>
+      <li>Open <a href="app.html">read-aloud.com/app</a> in Safari.</li>
+      <li>Tap the Share icon, scroll down, and tap <strong>Add to Home Screen</strong>.</li>
+      <li>Rename it to “Read‑Aloud” so you recognize it quickly.</li>
+    </ul>
+    <p>This creates an app-like icon that launches directly into the tool with your last used settings.</p>
+  </section>
+
+  <section class="card">
+    <h2>Android</h2>
+    <ul>
+      <li>Open the tool in Chrome.</li>
+      <li>Tap the three dots menu and choose <strong>Add to Home screen</strong>.</li>
+      <li>Accept the prompt to install the shortcut.</li>
+    </ul>
+    <p>If you use multiple profiles, create the shortcut in the profile that stores your preferred voice.</p>
+  </section>
+
+  <section class="card">
+    <h2>Want a bookmarklet?</h2>
+    <p>
+      Drag this link to your bookmarks bar: <a href="app.html" title="Open Read‑Aloud">Open Read‑Aloud</a>.
+      When clicked, it opens the tool in the current tab. Bookmarklets cannot send page text into the tool
+      for privacy reasons, but they make launching the player instant.
+    </p>
+    <p class="small">If you clear cookies or history often, re-pin the bookmark so it stays handy after cleanup.</p>
+  </section>
+</main>
+
+<footer>
+  <div>
     <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
+    <a href="app.html">Tool</a>
     <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
     <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
     <a href="privacy.html">Privacy</a>
     <a href="terms.html">Terms</a>
-  </nav>
-</header>
-    <h1>Text-to-Speech Reader</h1>
-    <p>Type or paste your text below to hear it read aloud.</p>
-
-    <textarea id="textInput" placeholder="Type or paste your text here..."></textarea>
-    <br>
-
-    <label for="languageSelect">Select Language:</label>
-    <select id="languageSelect" onchange="filterVoicesByLanguage()">
-        <option value="en" selected>English</option>
-        <option value="es">Spanish</option>
-        <option value="fr">French</option>
-        <option value="de">German</option>
-        <option value="it">Italian</option>
-    </select>
-    <br>
-
-    <label for="voiceSelect">Select Voice:</label>
-    <select id="voiceSelect">
-        <option value="-1">Default Voice (Fallback)</option>
-    </select>
-
-    <div class="button-container">
-        <button onclick="startReading()">Start</button>
-        <button onclick="pauseReading()">Pause</button>
-        <button onclick="resumeReading()">Resume</button>
-        <button onclick="stopReading()">Stop</button>
-    </div>
-
-    <div id="textDisplay"></div>
-
-    <div id="progressContainer">
-        <p><strong>Progress:</strong> <span id="progressPercent">0%</span></p>
-        <p><strong>Time Elapsed:</strong> <span id="timeElapsed">00:00:00</span></p>
-        <p><strong>Time Remaining:</strong> <span id="timeRemaining">00:00:00</span></p>
-    </div>
-
-    <script>
-        let speechSynthesisUtterance;
-        let voices = [];
-        let startWordIndex = 0;
-        let previousText = "";
-        let readingStartTime = null;
-
-        const textDisplay = document.getElementById('textDisplay');
-        const textInput = document.getElementById('textInput');
-        const voicesDropdown = document.getElementById('voiceSelect');
-        const languageDropdown = document.getElementById('languageSelect');
-
-        const progressPercent = document.getElementById('progressPercent');
-        const timeElapsed = document.getElementById('timeElapsed');
-        const timeRemaining = document.getElementById('timeRemaining');
-
-        const regionalVoicePriority = {
-            "en-US": ["Samantha", "Alex"],
-            "en-GB": ["Daniel", "Serena", "Moira"],
-            "en-AU": ["Karen", "Russell"],
-            "fr-FR": ["Thomas", "Audrey"],
-            "de-DE": ["Hans", "Marlene"],
-            "it-IT": ["Alice", "Luca"],
-        };
-
-        const excludedVoices = ["Jester", "Organ", "Bubbles", "Bad News", "Boing", "Wobble", "Grandma", "Grandpa", "Rocko", "Shelley", "Flo", "Eddy", "Reed"];
-
-        function updateTextDisplay() {
-            const text = textInput.value;
-            if (text !== previousText) {
-                const words = text.split(/(\s+)/);
-                textDisplay.innerHTML = words
-                    .map((word, index) => `<span data-index="${index}">${word}</span>`)
-                    .join('');
-                textDisplay.style.display = 'block';
-                previousText = text;
-                attachClickHandlers();
-            }
-        }
-
-        function attachClickHandlers() {
-            const spans = textDisplay.querySelectorAll('span');
-            spans.forEach(span => {
-                span.addEventListener('click', () => {
-                    const index = parseInt(span.getAttribute('data-index'), 10);
-                    startWordIndex = index;
-                    stopReading(); // Ensure previous utterances are cleared
-                    startReading();
-                });
-            });
-        }
-
-        function formatTime(seconds) {
-            const hrs = Math.floor(seconds / 3600).toString().padStart(2, '0');
-            const mins = Math.floor((seconds % 3600) / 60).toString().padStart(2, '0');
-            const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
-            return `${hrs}:${mins}:${secs}`;
-        }
-
-        function updateProgress(currentWordIndex, totalWords) {
-            const percent = Math.round((currentWordIndex / totalWords) * 100);
-            progressPercent.textContent = `${percent}%`;
-
-            const elapsedTime = Math.floor((Date.now() - readingStartTime) / 1000);
-            const estimatedTime = Math.round((totalWords - currentWordIndex) / 2);
-
-            timeElapsed.textContent = formatTime(elapsedTime);
-            timeRemaining.textContent = formatTime(estimatedTime);
-        }
-
-        function startReading() {
-            const text = textInput.value;
-
-            if (!text) {
-                alert('Please enter some text to read aloud.');
-                return;
-            }
-
-            if (speechSynthesis.speaking) {
-                speechSynthesis.cancel();
-            }
-
-            updateTextDisplay();
-
-            const words = text.split(/(\s+)/);
-            const selectedText = words.slice(startWordIndex).join('');
-
-            speechSynthesisUtterance = new SpeechSynthesisUtterance(selectedText);
-
-            const selectedVoiceIndex = parseInt(voicesDropdown.value, 10);
-            if (!isNaN(selectedVoiceIndex) && voices[selectedVoiceIndex]) {
-                speechSynthesisUtterance.voice = voices[selectedVoiceIndex];
-            }
-
-            speechSynthesisUtterance.rate = 1;
-            speechSynthesisUtterance.pitch = 1;
-
-            const totalWords = words.length;
-
-            readingStartTime = Date.now();
-
-            speechSynthesisUtterance.onboundary = (event) => {
-                const charIndex = event.charIndex;
-                let cumulativeCharCount = 0;
-                let foundIndex = startWordIndex;
-
-                const spans = textDisplay.querySelectorAll('span');
-
-                for (let i = 0; i < spans.length; i++) {
-                    cumulativeCharCount += spans[i].textContent.length;
-                    if (cumulativeCharCount > charIndex) {
-                        spans.forEach(span => span.classList.remove('highlight'));
-                        spans[i].classList.add('highlight');
-                        updateProgress(i, totalWords);
-                        foundIndex = i;
-                        break;
-                    }
-                }
-
-                startWordIndex = foundIndex;
-            };
-
-            speechSynthesisUtterance.onend = () => {
-                const spans = textDisplay.querySelectorAll('span');
-                spans.forEach(span => span.classList.remove('highlight'));
-                resetProgress();
-            };
-
-            speechSynthesis.speak(speechSynthesisUtterance);
-        }
-
-        function resetProgress() {
-            progressPercent.textContent = '0%';
-            timeElapsed.textContent = '00:00:00';
-            timeRemaining.textContent = '00:00:00';
-        }
-
-        function pauseReading() {
-            if (speechSynthesis.speaking) {
-                speechSynthesis.pause();
-            }
-        }
-
-        function resumeReading() {
-            if (speechSynthesis.paused) {
-                speechSynthesis.resume();
-            }
-        }
-
-        function stopReading() {
-            if (speechSynthesis.speaking) {
-                speechSynthesis.cancel();
-                const spans = textDisplay.querySelectorAll('span');
-                spans.forEach(span => span.classList.remove('highlight'));
-                resetProgress();
-            }
-        }
-
-        function filterVoicesByLanguage() {
-            const selectedLanguage = languageDropdown.value;
-            const prioritizedVoices = regionalVoicePriority[selectedLanguage + "-US"] || [];
-
-            let prioritizedOptions = [];
-            let fallbackOptions = [];
-
-            voices.forEach((voice, index) => {
-                if (excludedVoices.some(excluded => voice.name.includes(excluded))) {
-                    return;
-                }
-                const isPrioritized = prioritizedVoices.includes(voice.name);
-                const optionHTML = `<option value="${index}" ${isPrioritized ? 'selected' : ''}>${isPrioritized ? '🌟 ' : ''}${voice.name} (${voice.lang})</option>`;
-                if (isPrioritized) {
-                    prioritizedOptions.push(optionHTML);
-                } else if (voice.lang.startsWith(selectedLanguage)) {
-                    fallbackOptions.push(optionHTML);
-                }
-            });
-
-            voicesDropdown.innerHTML = `<option value="-1">Default Voice (Fallback)</option>` + prioritizedOptions.join('') + fallbackOptions.join('');
-        }
-
-        function populateVoices() {
-            voices = speechSynthesis.getVoices();
-            filterVoicesByLanguage();
-        }
-
-        textInput.addEventListener('input', updateTextDisplay);
-        speechSynthesis.addEventListener('voiceschanged', populateVoices);
-        populateVoices();
-
-    </script>
-
-    <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Keep the tool one tap away.</div>
 </footer>
 </body>
 </html>

--- a/bookmark.html
+++ b/bookmark.html
@@ -3,38 +3,37 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Bookmark Read‑Aloud | Quick Access Instructions</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="How to bookmark the Read‑Aloud tool on desktop and mobile so you can launch text-to-speech in one tap." />
-  <link rel="canonical" href="https://www.read-aloud.com/bookmark.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/bookmark.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Bookmark</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Bookmark</div>
   <h1>Bookmark Read‑Aloud</h1>
   <p class="lead">Save the tool so you can launch it with one tap. These steps keep the experience fast on laptops, tablets, and phones.</p>
 
   <section class="card">
     <h2>Desktop (Chrome, Edge, Firefox)</h2>
     <ul>
-      <li>Open <a href="app.html">read-aloud.com/app</a>.</li>
+      <li>Open <a href="/app.html">read-aloud.com/app</a>.</li>
       <li>Press <kbd>Ctrl</kbd>+<kbd>D</kbd> (Windows) or <kbd>Cmd</kbd>+<kbd>D</kbd> (macOS).</li>
       <li>Choose the Bookmarks Bar and click Save. Drag it to the left for quicker access.</li>
     </ul>
@@ -44,7 +43,7 @@
   <section class="card">
     <h2>iPhone or iPad</h2>
     <ul>
-      <li>Open <a href="app.html">read-aloud.com/app</a> in Safari.</li>
+      <li>Open <a href="/app.html">read-aloud.com/app</a> in Safari.</li>
       <li>Tap the Share icon, scroll down, and tap <strong>Add to Home Screen</strong>.</li>
       <li>Rename it to “Read‑Aloud” so you recognize it quickly.</li>
     </ul>
@@ -64,7 +63,7 @@
   <section class="card">
     <h2>Want a bookmarklet?</h2>
     <p>
-      Drag this link to your bookmarks bar: <a href="app.html" title="Open Read‑Aloud">Open Read‑Aloud</a>.
+      Drag this link to your bookmarks bar: <a href="/app.html" title="Open Read‑Aloud">Open Read‑Aloud</a>.
       When clicked, it opens the tool in the current tab. Bookmarklets cannot send page text into the tool
       for privacy reasons, but they make launching the player instant.
     </p>
@@ -74,18 +73,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Keep the tool one tap away.</div>
 </footer>

--- a/contact.html
+++ b/contact.html
@@ -9,31 +9,30 @@
     gtag('js', new Date());
     gtag('config', 'G-SVGML1VGPG');
   </script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Contact | Read‑Aloud Support</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Contact Read‑Aloud for support or feedback. Includes response times, bug report template, and guidance on what information to share." />
-  <link rel="canonical" href="https://www.read-aloud.com/contact.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/contact.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Contact</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Contact</div>
   <h1>Contact</h1>
   <p class="lead">Reach out for support, feedback, or partnership ideas. Read‑Aloud is a small project; clear details help us reply quickly.</p>
 
@@ -71,18 +70,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html" aria-current="page">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html" aria-current="page">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. We never ask for sensitive documents over email.</div>
 </footer>

--- a/contact.html
+++ b/contact.html
@@ -1,71 +1,90 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-<meta charset="utf-8">
-<title>Contact | Read-Aloud</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="description" content="Contact the Read-Aloud team for support or feedback.">
-<style>
-body{margin:0;font:16px/1.6 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:720px;margin:auto;padding:26px}
-label{display:block;margin:12px 0 4px}
-input,textarea{width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;font-size:15px;box-sizing:border-box}
-button{margin-top:12px;padding:10px 18px;background:#ff0;border:2px solid #777;font:15px/1.2 Tahoma;cursor:pointer;color:#000}
-</style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SVGML1VGPG');
+  </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Contact | Read‑Aloud Support</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Contact Read‑Aloud for support or feedback. Includes response times, bug report template, and guidance on what information to share." />
+  <link rel="canonical" href="https://www.read-aloud.com/contact.html">
+  <link rel="stylesheet" href="site.css">
 </head>
-
 <body>
 <header>
-  <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
 </header>
 
 <main>
-  <h1>Contact Us</h1>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Contact</div>
+  <h1>Contact</h1>
+  <p class="lead">Reach out for support, feedback, or partnership ideas. Read‑Aloud is a small project; clear details help us reply quickly.</p>
 
-  <p>Have feedback, feature requests or bug reports?  
-     Send a message with the form below or email
-     <a href="mailto:admin@read-aloud.com">admin@read-aloud.com</a>.</p>
+  <section class="card">
+    <h2 style="margin-top:0">Response time</h2>
+    <p>
+      We aim to respond within two business days. Complex reports that require reproducing device-specific issues may take a bit longer. If you are reporting a time-sensitive classroom issue, mention the date so we can triage accordingly.
+    </p>
+  </section>
 
-  <!-- simple Formspree endpoint; replace with your own key -->
-  <form action="https://formspree.io/f/yourFormID" method="POST">
-    <label for="name">Name</label>
-    <input required id="name" name="name" type="text">
+  <section class="card">
+    <h2 style="margin-top:0">Bug report template</h2>
+    <p>Copy and paste this checklist so we can reproduce your issue:</p>
+    <ul>
+      <li><strong>Browser &amp; version:</strong> (Example: Chrome 122, Safari 17)</li>
+      <li><strong>Device &amp; OS:</strong> (Example: MacBook Air macOS 14.3, iPadOS 17.4, Windows 11)</li>
+      <li><strong>What you tried:</strong> (Start, Pause, Resume, changing speed, switching voice)</li>
+      <li><strong>What happened:</strong> (No sound, voice list empty, playback stops at 30%)</li>
+      <li><strong>Exact text length:</strong> (Rough word count or a short snippet helps)</li>
+      <li><strong>Screenshots if relevant:</strong> (Especially for missing controls or errors)</li>
+    </ul>
+    <p>Send the details to <a href="mailto:hello@read-aloud.com">hello@read-aloud.com</a>. For privacy, remove any sensitive text before sharing screenshots.</p>
+  </section>
 
-    <label for="email">Email</label>
-    <input required id="email" name="_replyto" type="email">
-
-    <label for="msg">Message</label>
-    <textarea required id="msg" name="message" rows="6"></textarea>
-
-    <button type="submit">Send Message</button>
-  </form>
+  <section class="card">
+    <h2 style="margin-top:0">What to share (and what not to)</h2>
+    <p>
+      Helpful: device/OS versions, browser version, whether audio works on other sites, whether you tried another browser, and the size of your pasted text. These details point us to browser quirks faster.
+    </p>
+    <p>
+      Please do <strong>not</strong> send full legal documents, student records, or medical information. A short placeholder paragraph with the same length or characters (for example, “lorem ipsum” of equal size) is enough for us to test playback behavior.
+    </p>
+  </section>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html">Tool</a>
+    <a href="guides.html">Guides</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
+    <a href="about.html">About</a>
+    <a href="contact.html" aria-current="page">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. We never ask for sensitive documents over email.</div>
 </footer>
 </body>
 </html>

--- a/download-mp3.html
+++ b/download-mp3.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Why MP3 Export Is Limited | Read‑Aloud</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Understand why the browser text-to-speech API cannot export MP3 files and learn safe alternatives for offline listening." />
-  <link rel="canonical" href="https://www.read-aloud.com/download-mp3.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/download-mp3.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> MP3 Export</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> MP3 Export</div>
   <h1>Why MP3 Export Is Limited</h1>
   <p class="lead">Read‑Aloud relies on the browser’s Speech Synthesis API, which is designed for live playback, not file generation. Here is what that means and how to handle offline needs safely.</p>
 
@@ -44,7 +43,7 @@
     <h2>Safe alternatives</h2>
     <ul>
       <li>Use your operating system’s screen recorder with system audio while the text plays. Confirm you have rights to the material before recording.</li>
-      <li>For repeated listening, save the cleaned text in a secure document and replay it later in the <a href="app.html">tool</a>.</li>
+      <li>For repeated listening, save the cleaned text in a secure document and replay it later in the <a href="/app.html">tool</a>.</li>
       <li>If you need downloadable audio for accessibility documentation, consider dedicated TTS software that provides export with proper permissions.</li>
     </ul>
   </section>
@@ -67,18 +66,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Live playback keeps your text private.</div>
 </footer>

--- a/download-mp3.html
+++ b/download-mp3.html
@@ -1,531 +1,86 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Download MP3 (Offline Voice) · Read‑Aloud</title>
-  <meta name="description" content="Generate a downloadable WAV or MP3 using an offline TTS voice. This does not export your browser's system voices." />
-  <style>
-    :root { color-scheme: light dark; }
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; max-width: 920px; margin: 0 auto; padding: 20px; line-height: 1.4; }
-    nav { display:flex; gap:12px; flex-wrap:wrap; margin-bottom: 16px; }
-    nav a { text-decoration:none; padding: 6px 10px; border-radius: 8px; border: 1px solid rgba(127,127,127,.35); }
-    h1 { margin: 12px 0 8px; }
-    .note { padding: 12px 14px; border: 1px solid rgba(127,127,127,.35); border-radius: 12px; background: rgba(127,127,127,.08); }
-    .grid { display:grid; grid-template-columns: 1fr; gap: 12px; margin-top: 12px; }
-    @media (min-width: 900px) { .grid { grid-template-columns: 1.15fr .85fr; } }
-    textarea { width: 100%; min-height: 240px; padding: 10px; border-radius: 12px; border: 1px solid rgba(127,127,127,.35); font: inherit; }
-    label { display:block; font-weight: 600; margin: 10px 0 6px; }
-    select, input[type="number"], input[type="text"] { width: 100%; padding: 9px 10px; border-radius: 10px; border: 1px solid rgba(127,127,127,.35); font: inherit; }
-    .row { display:flex; gap: 10px; flex-wrap: wrap; }
-    .row > * { flex: 1 1 220px; }
-    button { padding: 10px 14px; border-radius: 12px; border: 1px solid rgba(127,127,127,.35); font: inherit; cursor:pointer; }
-    button.primary { font-weight: 700; }
-    button:disabled { opacity: .6; cursor: not-allowed; }
-    .actions { display:flex; gap: 10px; flex-wrap: wrap; margin-top: 12px; }
-    .status { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 13px; opacity: .9; white-space: pre-wrap; }
-    footer { margin-top: 18px; opacity: .8; font-size: 14px; }
-    .fineprint { font-size: 14px; opacity: .9; }
-    .small { font-size: 14px; opacity: .9; }
-    .audio-wrap { margin-top: 10px; }
-    audio { width: 100%; }
-  </style>
-
-  <!-- MP3 encoder (small, browser-safe) -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/lamejs/1.2.1/lame.min.js"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Why MP3 Export Is Limited | Read‑Aloud</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Understand why the browser text-to-speech API cannot export MP3 files and learn safe alternatives for offline listening." />
+  <link rel="canonical" href="https://www.read-aloud.com/download-mp3.html">
+  <link rel="stylesheet" href="site.css">
 </head>
 <body>
 <header>
-  <nav id="mainNav">
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> MP3 Export</div>
+  <h1>Why MP3 Export Is Limited</h1>
+  <p class="lead">Read‑Aloud relies on the browser’s Speech Synthesis API, which is designed for live playback, not file generation. Here is what that means and how to handle offline needs safely.</p>
+
+  <section class="card">
+    <h2>No audio blobs from the API</h2>
+    <p>
+      The Speech Synthesis API streams audio directly to your speakers. It does not provide an MP3 or WAV
+      file to capture. Recording output would require extra permissions and could expose user text to
+      third parties, which conflicts with Read‑Aloud’s privacy-first design.
+    </p>
+  </section>
+
+  <section class="card">
+    <h2>Safe alternatives</h2>
+    <ul>
+      <li>Use your operating system’s screen recorder with system audio while the text plays. Confirm you have rights to the material before recording.</li>
+      <li>For repeated listening, save the cleaned text in a secure document and replay it later in the <a href="app.html">tool</a>.</li>
+      <li>If you need downloadable audio for accessibility documentation, consider dedicated TTS software that provides export with proper permissions.</li>
+    </ul>
+  </section>
+
+  <section class="card">
+    <h2>Offline playback tips</h2>
+    <p>
+      Read‑Aloud can continue speaking offline if the page and voice are already loaded. Before traveling,
+      open the tool, pick a voice, press Start briefly, then disconnect. Keep the tab open and avoid
+      refreshing while offline. For more, see the <a href="help.html#offline">offline section in Help</a>.
+    </p>
+    <p>
+      Remember that MP3 export is separate from privacy. By keeping audio live instead of downloadable, we
+      prevent accidental sharing of sensitive text. If you need to archive audio for compliance, work with
+      your organization’s approved recording tools and document that you have permission to store the
+      content.
+    </p>
+  </section>
+</main>
+
+<footer>
+  <div>
     <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
+    <a href="app.html">Tool</a>
     <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
     <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
     <a href="privacy.html">Privacy</a>
     <a href="terms.html">Terms</a>
-  </nav>
-</header>
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-  </nav>
-
-  <h1>Download MP3 (offline voice)</h1>
-
-  <div class="note">
-    <div><strong>Important:</strong> Browsers don’t provide a way to capture their built‑in system voices (Web Speech API) into an MP3 file. That’s why this page uses an <em>offline</em> synthesizer voice for exporting.</div>
-    <div style="margin-top:8px" class="fineprint">Your text is processed locally in your browser on this page. (No server upload.)</div>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
   </div>
-
-  <div class="grid">
-    <div>
-      <label for="text">Text to export</label>
-      <textarea id="text" placeholder="Paste or type text here…"></textarea>
-
-      <div class="actions">
-        <button class="primary" id="btnMp3">Generate MP3</button>
-        <button id="btnWav">Generate WAV</button>
-        <button id="btnClear" title="Clear text">Clear</button>
-      </div>
-
-      <div class="audio-wrap" id="audioWrap" style="display:none">
-        <label>Preview</label>
-        <audio id="audio" controls></audio>
-      </div>
-
-      <div style="margin-top:10px" class="status" id="status">Loading…</div>
-    </div>
-
-    <div>
-      <label for="voice">Offline voice</label>
-      <select id="voice">
-        <option value="en/en-us" selected>English (US)</option>
-        <option value="en/en">English</option>
-        <option value="en/en-sc">English (Scottish)</option>
-        <option value="en/en-rp">English (RP)</option>
-        <option value="es/es">Spanish</option>
-        <option value="es-la/es-la">Spanish (Latin America)</option>
-        <option value="fr/fr">French</option>
-        <option value="de/de">German</option>
-        <option value="it/it">Italian</option>
-        <option value="nl/nl">Dutch</option>
-        <option value="pt/pt-br">Portuguese (Brazil)</option>
-        <option value="sv/sv">Swedish</option>
-        <option value="tr/tr">Turkish</option>
-      </select>
-
-      <div class="row">
-        <div>
-          <label for="speed">Speed (words per minute)</label>
-          <input id="speed" type="number" min="80" max="300" step="5" value="175" />
-          <div class="fineprint">Offline voice speed is in <em>words per minute</em>.</div>
-        </div>
-        <div>
-          <label for="pitch">Pitch (0–99)</label>
-          <input id="pitch" type="number" min="0" max="99" step="1" value="50" />
-        </div>
-      </div>
-
-      <div class="row">
-        <div>
-          <label for="bitrate">MP3 bitrate (kbps)</label>
-          <select id="bitrate">
-            <option value="96">96 kbps (small)</option>
-            <option value="128" selected>128 kbps (default)</option>
-            <option value="160">160 kbps</option>
-            <option value="192">192 kbps (bigger)</option>
-          </select>
-        </div>
-        <div>
-          <label for="filename">Filename (optional)</label>
-          <input id="filename" type="text" placeholder="read-aloud-export" />
-          <div class="fineprint">“.mp3” / “.wav” will be added automatically.</div>
-        </div>
-      </div>
-
-      <div class="fineprint" style="margin-top:12px">
-        Tips:
-        <ul>
-          <li>For very long text, export in chunks (e.g., 2–5 minutes at a time) to avoid heavy CPU usage—especially on phones.</li>
-          <li>If you want <strong>natural</strong> voices in the MP3, you’ll need a server-side TTS provider (which means sending text off-device).</li>
-        </ul>
-      </div>
-    </div>
-  </div>
-
-  <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <div class="legal">© 2025 Read‑Aloud. Live playback keeps your text private.</div>
 </footer>
-
-<script>
-(function () {
-  const $ = (id) => document.getElementById(id);
-
-  const els = {
-    text: $("text"),
-    voice: $("voice"),
-    speed: $("speed"),
-    pitch: $("pitch"),
-    bitrate: $("bitrate"),
-    filename: $("filename"),
-    btnMp3: $("btnMp3"),
-    btnWav: $("btnWav"),
-    btnClear: $("btnClear"),
-    status: $("status"),
-    audioWrap: $("audioWrap"),
-    audio: $("audio"),
-  };
-
-  function setStatus(msg) { els.status.textContent = msg; }
-  function disableButtons(disabled) {
-    els.btnMp3.disabled = disabled;
-    els.btnWav.disabled = disabled;
-    els.btnClear.disabled = disabled;
-  }
-
-  function safeBaseName() {
-    const raw = (els.filename.value || "").trim();
-    if (raw) return raw.replace(/[^a-z0-9\-_ ]/gi, "").trim().replace(/\s+/g, "-").slice(0, 60) || "read-aloud-export";
-    return "read-aloud-export";
-  }
-
-  function downloadBlob(blob, filename) {
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    setTimeout(() => URL.revokeObjectURL(url), 2000);
-  }
-
-  // --- Load meSpeak (offline synthesizer) ---
-  const MESPEAK_CANDIDATE_SCRIPTS = [
-    "/mespeak/mespeak.js",
-    "/mespeak.js",
-    "/js/mespeak.js",
-    "mespeak.js",
-    "https://cdn.jsdelivr.net/gh/btopro/mespeak@master/mespeak.js"
-  ];
-
-  function loadScript(url) {
-    return new Promise((resolve, reject) => {
-      const s = document.createElement("script");
-      s.src = url;
-      s.async = true;
-      s.onload = () => resolve(url);
-      s.onerror = () => reject(new Error("Failed to load: " + url));
-      document.head.appendChild(s);
-    });
-  }
-
-  function dirnameUrl(url) {
-    const u = new URL(url, window.location.href);
-    const path = u.pathname;
-    const basePath = path.substring(0, path.lastIndexOf("/") + 1);
-    return u.origin + basePath;
-  }
-
-  let voiceBaseUrl = null;
-
-  async function loadMeSpeak() {
-    for (const url of MESPEAK_CANDIDATE_SCRIPTS) {
-      try {
-        await loadScript(url);
-        if (!window.meSpeak) continue;
-
-        const base = dirnameUrl(url);
-        // Try loading config if this meSpeak build needs it.
-        try {
-          if (typeof meSpeak.loadConfig === "function") {
-            // most builds use mespeak_config.json next to mespeak.js
-            meSpeak.loadConfig(base + "mespeak_config.json");
-          }
-        } catch (_) {}
-
-        // Prefer voices/ next to mespeak.js (common layout)
-        const candidateVoiceBases = [
-          base + "voices/",
-          base + "mespeak/voices/",
-          window.location.origin + "/voices/",
-          window.location.origin + "/mespeak/voices/",
-          "https://cdn.jsdelivr.net/gh/btopro/mespeak@master/voices/"
-        ];
-
-        // Find a voiceBase that can actually load a known voice.
-        for (const vb of candidateVoiceBases) {
-          try {
-            await loadVoiceWithBase("en/en-us", vb);
-            voiceBaseUrl = vb;
-            return;
-          } catch (_) {}
-        }
-      } catch (_) {}
-    }
-    throw new Error("Could not load the offline voice engine (meSpeak).");
-  }
-
-  function loadVoiceWithBase(voiceId, baseUrl) {
-    return new Promise((resolve, reject) => {
-      const voiceUrl = baseUrl + voiceId + ".json";
-      if (!window.meSpeak || typeof meSpeak.loadVoice !== "function") {
-        reject(new Error("meSpeak.loadVoice is not available."));
-        return;
-      }
-      meSpeak.loadVoice(voiceUrl, (success, msgOrId) => {
-        if (!success) reject(new Error(msgOrId || "Voice load failed: " + voiceUrl));
-        else resolve(true);
-      });
-    });
-  }
-
-  async function loadSelectedVoice() {
-    const voiceId = els.voice.value;
-    if (!voiceBaseUrl) throw new Error("Voice base URL not set.");
-    await loadVoiceWithBase(voiceId, voiceBaseUrl);
-  }
-
-  // WAV parsing -> PCM Int16 arrays
-  function readAscii(view, offset, len) {
-    let s = "";
-    for (let i = 0; i < len; i++) s += String.fromCharCode(view.getUint8(offset + i));
-    return s;
-  }
-
-  function parseWav(arrayBuffer) {
-    const view = new DataView(arrayBuffer);
-    if (readAscii(view, 0, 4) !== "RIFF" || readAscii(view, 8, 4) !== "WAVE") {
-      throw new Error("Not a valid WAV (missing RIFF/WAVE header).");
-    }
-
-    let pos = 12;
-    let fmt = null;
-    let dataOffset = null;
-    let dataSize = null;
-
-    while (pos + 8 <= view.byteLength) {
-      const id = readAscii(view, pos, 4);
-      const size = view.getUint32(pos + 4, true);
-      const chunkData = pos + 8;
-
-      if (id === "fmt ") {
-        const audioFormat = view.getUint16(chunkData + 0, true);
-        const numChannels = view.getUint16(chunkData + 2, true);
-        const sampleRate = view.getUint32(chunkData + 4, true);
-        const bitsPerSample = view.getUint16(chunkData + 14, true);
-        fmt = { audioFormat, numChannels, sampleRate, bitsPerSample };
-      } else if (id === "data") {
-        dataOffset = chunkData;
-        dataSize = size;
-        break;
-      }
-
-      pos = chunkData + size;
-      if (size % 2 === 1) pos += 1;
-    }
-
-    if (!fmt) throw new Error("WAV parse error: missing fmt chunk.");
-    if (dataOffset == null || dataSize == null) throw new Error("WAV parse error: missing data chunk.");
-    if (fmt.audioFormat !== 1) throw new Error("Unsupported WAV: only PCM (format 1) is supported.");
-    if (fmt.numChannels < 1 || fmt.numChannels > 2) throw new Error("Unsupported WAV: only mono/stereo supported.");
-    if (fmt.bitsPerSample !== 8 && fmt.bitsPerSample !== 16) throw new Error("Unsupported WAV: expected 8-bit or 16-bit PCM.");
-
-    const bytesPerSample = fmt.bitsPerSample / 8;
-    const frameCount = Math.floor(dataSize / (bytesPerSample * fmt.numChannels));
-    const channels = Array.from({ length: fmt.numChannels }, () => new Int16Array(frameCount));
-
-    for (let i = 0; i < frameCount; i++) {
-      for (let ch = 0; ch < fmt.numChannels; ch++) {
-        const sampleIndex = i * fmt.numChannels + ch;
-        const sampleOffset = dataOffset + sampleIndex * bytesPerSample;
-        let sample16;
-
-        if (fmt.bitsPerSample === 8) {
-          const u8 = view.getUint8(sampleOffset);
-          sample16 = (u8 - 128) << 8;
-        } else {
-          sample16 = view.getInt16(sampleOffset, true);
-        }
-        channels[ch][i] = sample16;
-      }
-    }
-
-    return { sampleRate: fmt.sampleRate, numChannels: fmt.numChannels, channels };
-  }
-
-  async function encodeMp3FromWavBuffer(wavArrayBuffer, kbps, onProgress) {
-    const wav = parseWav(wavArrayBuffer);
-    const mp3Encoder = new lamejs.Mp3Encoder(wav.numChannels, wav.sampleRate, kbps);
-
-    const blockSize = 1152;
-    const mp3Chunks = [];
-    const totalSamples = wav.channels[0].length;
-
-    for (let i = 0; i < totalSamples; i += blockSize) {
-      const left = wav.channels[0].subarray(i, i + blockSize);
-      let mp3buf;
-
-      if (wav.numChannels === 1) {
-        mp3buf = mp3Encoder.encodeBuffer(left);
-      } else {
-        const right = wav.channels[1].subarray(i, i + blockSize);
-        mp3buf = mp3Encoder.encodeBuffer(left, right);
-      }
-
-      if (mp3buf && mp3buf.length) mp3Chunks.push(mp3buf);
-      if (onProgress) onProgress(Math.min(1, i / totalSamples));
-      if (i % (blockSize * 120) === 0) await new Promise(r => setTimeout(r, 0));
-    }
-
-    const end = mp3Encoder.flush();
-    if (end && end.length) mp3Chunks.push(end);
-
-    return new Blob(mp3Chunks, { type: "audio/mpeg" });
-  }
-
-  function toArrayBufferMaybe(stream) {
-    if (!stream) return null;
-    if (stream instanceof ArrayBuffer) return stream;
-    if (ArrayBuffer.isView(stream)) {
-      const u8 = new Uint8Array(stream.buffer, stream.byteOffset, stream.byteLength);
-      return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
-    }
-    if (Array.isArray(stream)) return new Uint8Array(stream).buffer;
-    return null;
-  }
-
-  function synthesizeWav(text, opts) {
-    return new Promise((resolve, reject) => {
-      const options = Object.assign({}, opts, { rawdata: true });
-      let returned;
-
-      try {
-        returned = meSpeak.speak(text, options, (success, id, wavStream) => {
-          const buf = toArrayBufferMaybe(wavStream) || toArrayBufferMaybe(returned);
-          if (success && buf) resolve(buf);
-          else if (!success) reject(new Error("Speech synthesis failed."));
-          else reject(new Error("Speech synthesis did not return WAV data."));
-        });
-      } catch (e) {
-        reject(e);
-        return;
-      }
-
-      const buf = toArrayBufferMaybe(returned);
-      if (buf) resolve(buf); // older builds return stream synchronously
-    });
-  }
-
-  // --- UI actions ---
-  els.btnClear.addEventListener("click", () => {
-    els.text.value = "";
-    els.audioWrap.style.display = "none";
-    els.audio.removeAttribute("src");
-    setStatus("Cleared.");
-  });
-
-  els.voice.addEventListener("change", async () => {
-    try {
-      disableButtons(true);
-      setStatus("Loading voice…");
-      await loadSelectedVoice();
-      setStatus("Voice loaded.");
-    } catch (e) {
-      setStatus("Voice load error: " + (e && e.message ? e.message : e));
-    } finally {
-      disableButtons(false);
-    }
-  });
-
-  els.btnWav.addEventListener("click", async () => {
-    const text = (els.text.value || "").trim();
-    if (!text) { setStatus("Paste some text first."); return; }
-
-    disableButtons(true);
-    els.audioWrap.style.display = "none";
-    els.audio.removeAttribute("src");
-
-    try {
-      setStatus("Synthesizing WAV…");
-      await loadSelectedVoice();
-
-      const wavBuf = await synthesizeWav(text, {
-        speed: Number(els.speed.value) || 175,
-        pitch: Number(els.pitch.value) || 50,
-      });
-
-      const wavBlob = new Blob([wavBuf], { type: "audio/wav" });
-      const filename = safeBaseName() + ".wav";
-      downloadBlob(wavBlob, filename);
-
-      const url = URL.createObjectURL(wavBlob);
-      els.audio.src = url;
-      els.audioWrap.style.display = "block";
-
-      setStatus("WAV ready: " + filename);
-    } catch (e) {
-      setStatus("Error: " + (e && e.message ? e.message : e));
-    } finally {
-      disableButtons(false);
-    }
-  });
-
-  els.btnMp3.addEventListener("click", async () => {
-    const text = (els.text.value || "").trim();
-    if (!text) { setStatus("Paste some text first."); return; }
-
-    disableButtons(true);
-    els.audioWrap.style.display = "none";
-    els.audio.removeAttribute("src");
-
-    try {
-      const kbps = Number(els.bitrate.value) || 128;
-      setStatus("Synthesizing WAV…");
-      await loadSelectedVoice();
-
-      const wavBuf = await synthesizeWav(text, {
-        speed: Number(els.speed.value) || 175,
-        pitch: Number(els.pitch.value) || 50,
-      });
-
-      setStatus("Encoding MP3 (" + kbps + " kbps)… 0%");
-      const mp3Blob = await encodeMp3FromWavBuffer(wavBuf, kbps, (p) => {
-        const pct = Math.floor(p * 100);
-        if (pct % 5 === 0) setStatus("Encoding MP3 (" + kbps + " kbps)… " + pct + "%");
-      });
-
-      const filename = safeBaseName() + ".mp3";
-      downloadBlob(mp3Blob, filename);
-
-      const url = URL.createObjectURL(mp3Blob);
-      els.audio.src = url;
-      els.audioWrap.style.display = "block";
-
-      setStatus("MP3 ready: " + filename);
-    } catch (e) {
-      setStatus("Error: " + (e && e.message ? e.message : e));
-    } finally {
-      disableButtons(false);
-    }
-  });
-
-  // --- Boot ---
-  (async () => {
-    try {
-      disableButtons(true);
-      if (!window.lamejs || !window.lamejs.Mp3Encoder) throw new Error("MP3 encoder failed to load.");
-      setStatus("Loading offline voice engine…");
-      await loadMeSpeak();
-      await loadSelectedVoice();
-      setStatus("Ready. Paste text and click “Generate MP3”.");
-    } catch (e) {
-      setStatus(
-        "Startup error: " + (e && e.message ? e.message : e) +
-        "\n\nFix: Make sure your repo contains meSpeak (mespeak.js + voices folder), or allow the fallback CDN URLs. Some ad blockers block CDNs."
-      );
-    } finally {
-      disableButtons(false);
-    }
-  })();
-})();
-</script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -27,19 +27,21 @@
   ul{padding-left:20px}
   hr{margin:24px 0}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/faq.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -48,8 +50,8 @@
   <p class="small"><strong>Last updated:</strong> December 2025</p>
 
   <div class="box">
-    If your question is “something is broken,” start with <a href="help.html">Help & Troubleshooting</a>.
-    If your question is “how do I use this for school/work,” start with <a href="guides.html">Guides</a>.
+    If your question is “something is broken,” start with <a href="/help.html">Help & Troubleshooting</a>.
+    If your question is “how do I use this for school/work,” start with <a href="/guides.html">Guides</a>.
   </div>
 
   <h2>Is Read‑Aloud free?</h2>
@@ -73,7 +75,7 @@
   <h2>I clicked “Start” but hear nothing on iPhone/iPad.</h2>
   <p>
     iOS is strict about audio playback. Check the Ring/Silent switch, disable Lockdown Mode, refresh, and tap Start again.
-    See the full checklist on <a href="help.html">Help</a>.
+    See the full checklist on <a href="/help.html">Help</a>.
   </p>
 
   <h2>Can I download an MP3?</h2>
@@ -89,11 +91,11 @@
   </ul>
 
   <hr>
-  <p class="small">More: <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a></p>
+  <p class="small">More: <a href="/contact.html">Contact</a> · <a href="/terms.html">Terms</a></p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/guide-browser-compatibility.html
+++ b/guide-browser-compatibility.html
@@ -32,19 +32,21 @@ th{background:#f2f2f2}
 ul{padding-left:20px}
 hr{margin:24px 0}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/guide-browser-compatibility.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -123,7 +125,7 @@ hr{margin:24px 0}
         <td>Uses iOS voices; audio requires a user action (tap Start).</td>
         <td>
           <strong>Issue:</strong> “Start” but no sound / voices empty.<br>
-          <strong>Fix:</strong> check Ring/Silent switch, disable Lockdown Mode, refresh, then tap Start again. See <a href="help.html">Help</a>.
+          <strong>Fix:</strong> check Ring/Silent switch, disable Lockdown Mode, refresh, then tap Start again. See <a href="/help.html">Help</a>.
         </td>
       </tr>
       <tr>
@@ -160,7 +162,7 @@ hr{margin:24px 0}
     <ul>
       <li><strong>Refresh once.</strong> Voice lists can load late.</li>
       <li><strong>Tap Start.</strong> On mobile, audio often requires a direct user action.</li>
-      <li><strong>iPhone/iPad:</strong> check Ring/Silent switch (not orange), disable Lockdown Mode, refresh, then tap Start again. (Full checklist: <a href="help.html">Help</a>.)</li>
+      <li><strong>iPhone/iPad:</strong> check Ring/Silent switch (not orange), disable Lockdown Mode, refresh, then tap Start again. (Full checklist: <a href="/help.html">Help</a>.)</li>
       <li><strong>Try another browser.</strong> Chrome/Edge/Safari can expose different voice lists.</li>
       <li><strong>Try another voice.</strong> Some voices sound robotic or handle punctuation differently.</li>
     </ul>
@@ -176,12 +178,12 @@ hr{margin:24px 0}
   <p class="small">
     Related: <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
     <a href="guide-mp3-export.html">Why MP3 export is hard</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/guide-dyslexia-adhd.html
+++ b/guide-dyslexia-adhd.html
@@ -28,19 +28,21 @@ ul{padding-left:20px}
 .small{color:#444;font-size:0.95em}
 hr{margin:24px 0}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/guide-dyslexia-adhd.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -67,9 +69,9 @@ hr{margin:24px 0}
 
   <h2>Setup That Works for Most People</h2>
   <ol>
-    <li>Open <a href="index.html">Read‑Aloud</a> and paste your text.</li>
+    <li>Open <a href="/index.html">Read‑Aloud</a> and paste your text.</li>
     <li>Set speed to <strong>0.9×</strong> (start slightly slow).</li>
-    <li>Pick a voice that feels calm and clear (use <a href="voices.html">Voice Gallery</a> to preview).</li>
+    <li>Pick a voice that feels calm and clear (use <a href="/voices.html">Voice Gallery</a> to preview).</li>
     <li>Read in <strong>short chunks</strong> (3–10 minutes), then pause.</li>
   </ol>
 
@@ -132,12 +134,12 @@ hr{margin:24px 0}
   <p class="small">
     Next: <a href="guide-study.html">Study with TTS</a> ·
     <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/guide-how-to-use.html
+++ b/guide-how-to-use.html
@@ -32,19 +32,21 @@ hr{margin:24px 0}
 code,kbd{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace}
 kbd{border:1px solid #bbb;border-bottom:2px solid #999;border-radius:6px;padding:2px 6px;background:#fff}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/guide-how-to-use.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -57,14 +59,14 @@ kbd{border:1px solid #bbb;border-bottom:2px solid #999;border-radius:6px;padding
     <ul>
       <li><strong>Your voices come from your browser/OS.</strong> If your voice list looks different on another device or browser, that’s normal.</li>
       <li><strong>If a voice sounds robotic:</strong> try a different voice, or try another browser (desktop Chrome/Edge are often the most reliable).</li>
-      <li><strong>iPhone/iPad “no sound”:</strong> check <a href="help.html">Help</a> (Ring/Silent switch, Lockdown Mode, refresh, and tap <strong>Start</strong> again).</li>
+      <li><strong>iPhone/iPad “no sound”:</strong> check <a href="/help.html">Help</a> (Ring/Silent switch, Lockdown Mode, refresh, and tap <strong>Start</strong> again).</li>
     </ul>
     <p class="small">More detail: <a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability</a></p>
   </div>
 
   <h2>Quick start (30 seconds)</h2>
   <ol>
-    <li>Open the <a href="index.html">Read‑Aloud tool</a>.</li>
+    <li>Open the <a href="/index.html">Read‑Aloud tool</a>.</li>
     <li>Paste your text into the main text box.</li>
     <li>Select a <strong>Language</strong> and <strong>Voice</strong> (or keep <em>Default</em>).</li>
     <li>Adjust <strong>Speed</strong> if you want (0.9× is a good starting point for studying).</li>
@@ -102,7 +104,7 @@ Question: does it pause correctly after commas, periods, and question marks?</pr
 
   <h2>Common problems (and fixes)</h2>
   <ul>
-    <li><strong>“I pressed Start but hear nothing (iPhone/iPad)”</strong>: make sure the Ring/Silent switch isn’t set to silent, disable Lockdown Mode, refresh the page, then tap <strong>Start</strong> again. See <a href="help.html">Help</a>.</li>
+    <li><strong>“I pressed Start but hear nothing (iPhone/iPad)”</strong>: make sure the Ring/Silent switch isn’t set to silent, disable Lockdown Mode, refresh the page, then tap <strong>Start</strong> again. See <a href="/help.html">Help</a>.</li>
     <li><strong>“My voice list is empty”</strong>: refresh, tap <strong>Start</strong> once, then check again. If needed, try another browser or update your OS.</li>
     <li><strong>“It stops mid‑way through a long text”</strong>: split your text into smaller chunks (headings/sections) and play them one at a time.</li>
   </ul>
@@ -117,12 +119,12 @@ Question: does it pause correctly after commas, periods, and question marks?</pr
   <p class="small">
     Next: <a href="guide-study.html">Study with TTS</a> ·
     <a href="guide-proofread.html">Proofread by Ear</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/guide-language-learning.html
+++ b/guide-language-learning.html
@@ -30,19 +30,21 @@ ul{padding-left:20px}
 .small{color:#444;font-size:0.95em}
 hr{margin:24px 0}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/guide-language-learning.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -60,7 +62,7 @@ hr{margin:24px 0}
     <ul>
       <li><strong>Voice availability depends on your device.</strong> If you don’t see a voice for your target language, it usually means that language voice isn’t installed on your OS/browser.</li>
       <li><strong>If a voice sounds robotic:</strong> try another voice, or try another browser.</li>
-      <li><strong>iPhone/iPad tip:</strong> if audio is silent or voices don’t load, see <a href="help.html">Help</a>.</li>
+      <li><strong>iPhone/iPad tip:</strong> if audio is silent or voices don’t load, see <a href="/help.html">Help</a>.</li>
     </ul>
     <p class="small">Deep dive: <a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability</a></p>
   </div>
@@ -75,9 +77,9 @@ hr{margin:24px 0}
 
   <h2>Step 1: Choose a Language and Voice</h2>
   <ol>
-    <li>Open <a href="index.html">Read‑Aloud</a>.</li>
+    <li>Open <a href="/index.html">Read‑Aloud</a>.</li>
     <li>Select a <strong>Language</strong> that matches your target language.</li>
-    <li>Select a voice. If you’re unsure, preview options in <a href="voices.html">Voice Gallery</a>.</li>
+    <li>Select a voice. If you’re unsure, preview options in <a href="/voices.html">Voice Gallery</a>.</li>
     <li>Start at <strong>0.9×</strong> speed for accuracy, then increase later.</li>
   </ol>
 
@@ -149,12 +151,12 @@ FRANÇAIS (French)
   <p class="small">
     Next: <a href="guide-study.html">Study with TTS</a> ·
     <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/guide-mp3-export.html
+++ b/guide-mp3-export.html
@@ -32,19 +32,21 @@
   ul{padding-left:20px}
   hr{margin:24px 0}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/guide-mp3-export.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -143,12 +145,12 @@
   <p class="small">
     Related: <a href="guide-privacy.html">Privacy‑First Text‑to‑Speech</a> ·
     <a href="guide-browser-compatibility.html">Browser compatibility</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/guide-privacy.html
+++ b/guide-privacy.html
@@ -30,19 +30,21 @@ ul{padding-left:20px}
 .small{color:#444;font-size:0.95em}
 hr{margin:24px 0}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/guide-privacy.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -79,7 +81,7 @@ hr{margin:24px 0}
   <div class="specific">
     <ul>
       <li><strong>Voices come from your device.</strong> Different browsers/OSes expose different voice lists.</li>
-      <li><strong>On iPhone/iPad:</strong> if audio is silent or voices don’t load, see <a href="help.html">Help</a>.</li>
+      <li><strong>On iPhone/iPad:</strong> if audio is silent or voices don’t load, see <a href="/help.html">Help</a>.</li>
       <li><strong>MP3 export isn’t available (yet).</strong> That’s not just a missing button — it’s a real browser limitation. See the deep dive below.</li>
     </ul>
     <p class="small">Deep dives: <a href="guide-mp3-export.html">Why MP3 export is hard</a> · <a href="guide-browser-compatibility.html">Browser compatibility</a></p>
@@ -115,19 +117,19 @@ hr{margin:24px 0}
 
   <h2>Where to Learn More</h2>
   <ul>
-    <li><a href="privacy.html">Read‑Aloud Privacy Policy</a></li>
-    <li><a href="help.html">Help &amp; FAQ</a></li>
+    <li><a href="/privacy.html">Read‑Aloud Privacy Policy</a></li>
+    <li><a href="/help.html">Help &amp; FAQ</a></li>
   </ul>
 
   <hr>
   <p class="small">
     Next: <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/guide-proofread.html
+++ b/guide-proofread.html
@@ -30,19 +30,21 @@ ul{padding-left:20px}
 .small{color:#444;font-size:0.95em}
 hr{margin:24px 0}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/guide-proofread.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -67,12 +69,12 @@ hr{margin:24px 0}
       <li><strong>Voices are device-dependent.</strong> If a voice sounds wrong, try another voice (or another browser).</li>
       <li><strong>Pro editing tip:</strong> slow down slightly (0.85×–0.95×). Your ears catch missing words better when speech is a bit slower.</li>
     </ul>
-    <p class="small">If your voice list is empty or iOS audio is silent, see <a href="help.html">Help</a>.</p>
+    <p class="small">If your voice list is empty or iOS audio is silent, see <a href="/help.html">Help</a>.</p>
   </div>
 
   <h2>Quick Proofreading Workflow (10 Minutes)</h2>
   <ol>
-    <li>Paste your draft into <a href="index.html">Read‑Aloud</a>.</li>
+    <li>Paste your draft into <a href="/index.html">Read‑Aloud</a>.</li>
     <li>Set speed to <strong>0.9×</strong> (slightly slow helps catch issues).</li>
     <li>Press <strong>Start</strong> and follow along lightly.</li>
     <li>When you hear a problem, <strong>Pause</strong>, fix it in your original document, then resume.</li>
@@ -124,7 +126,7 @@ hr{margin:24px 0}
   <h2>Choose the Right Voice</h2>
   <p>
     A neutral voice is usually best for editing. If the voice is overly dramatic or robotic, it can distract you.
-    Try a couple in the <a href="voices.html">Voice Gallery</a> and pick the one that feels “invisible.”
+    Try a couple in the <a href="/voices.html">Voice Gallery</a> and pick the one that feels “invisible.”
   </p>
 
   <h2>Editing Prompts (Ask These While Listening)</h2>
@@ -147,12 +149,12 @@ hr{margin:24px 0}
   <p class="small">
     Next: <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
     <a href="guide-study.html">Study with TTS</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/guide-study.html
+++ b/guide-study.html
@@ -30,19 +30,21 @@ ul{padding-left:20px}
 .small{color:#444;font-size:0.95em}
 hr{margin:24px 0}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/guide-study.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -65,7 +67,7 @@ hr{margin:24px 0}
     <ul>
       <li><strong>Voices come from your browser/OS.</strong> If you don’t like how one voice sounds, switch voices (or try another browser).</li>
       <li><strong>Studying tip:</strong> for dense text, use a slightly slower speed (0.8×–0.95×) so you can summarize after each chunk.</li>
-      <li><strong>On iPhone/iPad:</strong> if you get no sound, see <a href="help.html">Help</a> (Ring/Silent switch, Lockdown Mode, refresh, tap Start again).</li>
+      <li><strong>On iPhone/iPad:</strong> if you get no sound, see <a href="/help.html">Help</a> (Ring/Silent switch, Lockdown Mode, refresh, tap Start again).</li>
     </ul>
     <p class="small">More detail: <a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability</a></p>
   </div>
@@ -73,7 +75,7 @@ hr{margin:24px 0}
   <h2>The 20-Minute TTS Study Loop</h2>
   <p>Try this loop (it’s deliberately simple):</p>
   <ol>
-    <li><strong>5 minutes:</strong> Paste a section into <a href="index.html">Read‑Aloud</a> and listen while lightly following with your eyes.</li>
+    <li><strong>5 minutes:</strong> Paste a section into <a href="/index.html">Read‑Aloud</a> and listen while lightly following with your eyes.</li>
     <li><strong>3 minutes:</strong> Pause and write 3 bullet points: “What did I just learn?”</li>
     <li><strong>7 minutes:</strong> Listen to the next section.</li>
     <li><strong>3 minutes:</strong> Write 1 question you could be tested on, and answer it without looking.</li>
@@ -162,12 +164,12 @@ Next step (choose one):
   <p class="small">
     Next: <a href="guide-dyslexia-adhd.html">TTS for Dyslexia &amp; ADHD</a> ·
     <a href="guide-proofread.html">Proofread by Ear</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/guides-how-to-use.html
+++ b/guides-how-to-use.html
@@ -29,19 +29,21 @@ ul{padding-left:20px}
 hr{margin:24px 0}
 .small{color:#444;font-size:0.95em}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/guides-how-to-use.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -56,7 +58,7 @@ hr{margin:24px 0}
 
   <h2>Quick Start (Desktop or Laptop)</h2>
   <ol>
-    <li>Open <a href="index.html">Read‑Aloud</a>.</li>
+    <li>Open <a href="/index.html">Read‑Aloud</a>.</li>
     <li>Paste or type text into the big text box.</li>
     <li>Pick a <strong>Language</strong> (optional).</li>
     <li>Pick a <strong>Voice</strong> (optional). “Default” is fine to begin.</li>
@@ -86,7 +88,7 @@ hr{margin:24px 0}
   <h2>Choosing a Voice (What to Expect)</h2>
   <p>
     Different browsers and operating systems ship with different voices. Some sound more natural than others.
-    If you want to preview common system voices, use the <a href="voices.html">Voice Gallery</a>.
+    If you want to preview common system voices, use the <a href="/voices.html">Voice Gallery</a>.
   </p>
 
   <div class="note">
@@ -132,12 +134,12 @@ hr{margin:24px 0}
   <p class="small">
     Next: <a href="guide-study.html">Study with Text‑to‑Speech</a> ·
     <a href="guide-proofread.html">Proofread by Ear</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/guides.html
+++ b/guides.html
@@ -1,115 +1,120 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-<meta charset="utf-8">
-<title>Guides & Tutorials | Read‑Aloud</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="description" content="Guides written specifically for read-aloud.com: studying, proofreading, dyslexia/ADHD support, language learning, privacy, and troubleshooting.">
-<style>
-body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-header a:hover,footer a:hover{text-decoration:underline}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0}
-.small{color:#444;font-size:0.95em}
-.card{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px;margin:12px 0}
-.specific{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-ul{padding-left:20px}
-hr{margin:24px 0}
-</style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SVGML1VGPG');
+  </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Guides &amp; Tutorials | Read‑Aloud</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Read‑Aloud guides for students, writers, accessibility, and language practice. Step-by-step workflows, pacing tips, and privacy guidance." />
+  <link rel="canonical" href="https://www.read-aloud.com/guides.html">
+  <link rel="stylesheet" href="site.css">
 </head>
-
 <body>
 <header>
-  <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html" aria-current="page">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html" aria-current="page">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
 </header>
 
 <main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Guides</div>
   <h1>Guides &amp; Tutorials</h1>
-  <p class="small"><strong>Start here.</strong> These guides are written specifically for <strong>read‑aloud.com</strong> — a browser-based text‑to‑speech tool that uses your device’s voices.</p>
+  <p class="lead">Deep dives on how different readers use Read‑Aloud. Pick a category to start, then jump into the guide that matches your workflow.</p>
+  <p class="card">Each guide is written for real-world scenarios—no generic filler. You will find pacing settings, device setup notes, and privacy reminders specific to Read‑Aloud so you can put the advice into practice without extra tools.</p>
 
-  <div class="specific">
-    <strong>Read‑Aloud specifics (important):</strong>
-    <ul>
-      <li><strong>Voice lists vary by browser &amp; OS.</strong> The same computer can show different voices in Chrome vs Safari vs Firefox.</li>
-      <li><strong>If a voice sounds robotic:</strong> switch voices, or try a different browser (desktop Chrome/Edge are often the most reliable).</li>
-      <li><strong>iPhone/iPad “no sound” or “no voices”:</strong> see <a href="help.html">Help</a> (Ring/Silent switch, Lockdown Mode, refresh, and “tap Start again”).</li>
-    </ul>
-    <p class="small">Deep dive: <a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability matrix</a></p>
-  </div>
+  <section class="card">
+    <h2 style="margin-top:0">Studying</h2>
+    <div class="grid two-col">
+      <div>
+        <h3><a href="guides/tts-for-students.html">Text-to-Speech for Students</a></h3>
+        <p>Build a realistic listening routine that improves comprehension, note-taking, and review without adding more screen time.</p>
+      </div>
+      <div>
+        <h3><a href="guides/tts-study-loop-templates.html">Copy/Paste Study Loop Templates</a></h3>
+        <p>Ready-to-use timers, prompts, and listening checklists to keep your focus anchored while the tool reads.</p>
+      </div>
+    </div>
+  </section>
 
-  <div class="card">
-    <h2 style="margin-top:0">Getting started</h2>
-    <ul>
-      <li><a href="guide-how-to-use.html">How to Use Read‑Aloud (Step‑by‑Step)</a> — what each control does + common fixes.</li>
-      <li><a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability</a> — why voices differ and how to troubleshoot.</li>
-    </ul>
-  </div>
+  <section class="card">
+    <h2 style="margin-top:0">Writing &amp; editing</h2>
+    <div class="grid two-col">
+      <div>
+        <h3><a href="guides/tts-for-writers.html">Text-to-Speech for Writers</a></h3>
+        <p>Turn Read‑Aloud into a proofreading partner that catches rhythm problems, filler words, and unclear pacing.</p>
+      </div>
+      <div>
+        <h3><a href="guides/tts-voice-selection.html">How to Choose the Best Voice</a></h3>
+        <p>Compare voice qualities, reduce listening fatigue, and map voice choices to different editing stages.</p>
+      </div>
+    </div>
+  </section>
 
-  <div class="card">
-    <h2 style="margin-top:0">Popular use‑cases</h2>
-    <ul>
-      <li><a href="guide-study.html">Study With Text‑to‑Speech</a> — a simple loop for better retention.</li>
-      <li><a href="guide-proofread.html">Proofread by Ear</a> — catch missing words, repetition, and awkward phrasing.</li>
-      <li><a href="guide-language-learning.html">Language Learning With TTS</a> — shadowing routines + practice scripts.</li>
-      <li><a href="guide-dyslexia-adhd.html">Dyslexia &amp; ADHD: Reading Support With TTS</a> — pacing, chunking, and focus strategies.</li>
-      <li><a href="guide-privacy.html">Privacy‑First Text‑to‑Speech</a> — what stays local, and what to watch for.</li>
-    </ul>
-  </div>
+  <section class="card">
+    <h2 style="margin-top:0">Accessibility &amp; focus</h2>
+    <div class="grid two-col">
+      <div>
+        <h3><a href="guides/tts-for-adhd-focus.html">TTS for Focus</a></h3>
+        <p>Chunking, timers, and pacing strategies tuned for ADHD brains that need steady anchors.</p>
+      </div>
+      <div>
+        <h3><a href="guides/tts-for-dyslexia-support.html">Dyslexia-Friendly Reading</a></h3>
+        <p>Dual reading tips, pacing ideas, and device setup for readers who benefit from audio support.</p>
+      </div>
+      <div>
+        <h3><a href="guides/tts-privacy-safety.html">Privacy &amp; Safety</a></h3>
+        <p>Learn what not to paste, why Read‑Aloud uses local voices, and habits that keep sensitive text out of the cloud.</p>
+      </div>
+    </div>
+  </section>
 
-  <div class="card">
-    <h2 style="margin-top:0">Deep dives (the “not generic” stuff)</h2>
-    <ul>
-      <li><a href="guide-mp3-export.html">Why MP3 download is hard in browser TTS</a> — the real technical + privacy tradeoffs.</li>
-      <li><a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability matrix</a> — what works best on desktop and mobile.</li>
-    </ul>
-  </div>
-
-  <h2>Before you paste text</h2>
-  <ul>
-    <li><strong>Use text you have the rights to use.</strong> (Your own writing, public domain text, permission-based material.)</li>
-    <li><strong>Be mindful with sensitive content.</strong> Avoid pasting private text on shared devices or while screen-sharing.</li>
-    <li><strong>For long documents:</strong> paste a section at a time (many browsers perform better with shorter chunks).</li>
-  </ul>
-
-  <h2>Support the site</h2>
-  <p>If Read‑Aloud helps you, you can support ongoing hosting and maintenance via <a href="https://coff.ee/readaloud" target="_blank" rel="noopener">Buy me a coffee</a>.</p>
-  <p class="small">
-    Looking for optional accessories that pair well with Read-Aloud? See
-    <a href="recommendations.html">Recommended reading aids &amp; accessories</a>.
-  </p>
-
-  <hr>
-  <p class="small">
-    Next: <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
-    <a href="index.html">Open the tool</a>
-  </p>
+  <section class="card">
+    <h2 style="margin-top:0">Language practice</h2>
+    <div class="grid two-col">
+      <div>
+        <h3><a href="guides/tts-for-language-shadowing.html">Shadowing Practice with TTS</a></h3>
+        <p>Set up scripts, pacing, and progress tracking for language learners who shadow native-like voices.</p>
+      </div>
+      <div>
+        <h3><a href="guides/tts-for-students.html#multilingual">Multilingual study tips</a></h3>
+        <p>Use the student workflow guide’s multilingual section for bilingual homework and pronunciation practice.</p>
+      </div>
+    </div>
+  </section>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html">Tool</a>
+    <a href="guides.html" aria-current="page">Guides</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
+    <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Guides are updated as browsers change.</div>
 </footer>
 </body>
 </html>

--- a/guides.html
+++ b/guides.html
@@ -9,31 +9,30 @@
     gtag('js', new Date());
     gtag('config', 'G-SVGML1VGPG');
   </script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Guides &amp; Tutorials | Read‑Aloud</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Read‑Aloud guides for students, writers, accessibility, and language practice. Step-by-step workflows, pacing tips, and privacy guidance." />
-  <link rel="canonical" href="https://www.read-aloud.com/guides.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/guides.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html" aria-current="page">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Guides</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Guides</div>
   <h1>Guides &amp; Tutorials</h1>
   <p class="lead">Deep dives on how different readers use Read‑Aloud. Pick a category to start, then jump into the guide that matches your workflow.</p>
   <p class="card">Each guide is written for real-world scenarios—no generic filler. You will find pacing settings, device setup notes, and privacy reminders specific to Read‑Aloud so you can put the advice into practice without extra tools.</p>
@@ -42,11 +41,11 @@
     <h2 style="margin-top:0">Studying</h2>
     <div class="grid two-col">
       <div>
-        <h3><a href="guides/tts-for-students.html">Text-to-Speech for Students</a></h3>
+        <h3><a href="/guides/tts-for-students.html">Text-to-Speech for Students</a></h3>
         <p>Build a realistic listening routine that improves comprehension, note-taking, and review without adding more screen time.</p>
       </div>
       <div>
-        <h3><a href="guides/tts-study-loop-templates.html">Copy/Paste Study Loop Templates</a></h3>
+        <h3><a href="/guides/tts-study-loop-templates.html">Copy/Paste Study Loop Templates</a></h3>
         <p>Ready-to-use timers, prompts, and listening checklists to keep your focus anchored while the tool reads.</p>
       </div>
     </div>
@@ -56,11 +55,11 @@
     <h2 style="margin-top:0">Writing &amp; editing</h2>
     <div class="grid two-col">
       <div>
-        <h3><a href="guides/tts-for-writers.html">Text-to-Speech for Writers</a></h3>
+        <h3><a href="/guides/tts-for-writers.html">Text-to-Speech for Writers</a></h3>
         <p>Turn Read‑Aloud into a proofreading partner that catches rhythm problems, filler words, and unclear pacing.</p>
       </div>
       <div>
-        <h3><a href="guides/tts-voice-selection.html">How to Choose the Best Voice</a></h3>
+        <h3><a href="/guides/tts-voice-selection.html">How to Choose the Best Voice</a></h3>
         <p>Compare voice qualities, reduce listening fatigue, and map voice choices to different editing stages.</p>
       </div>
     </div>
@@ -70,15 +69,15 @@
     <h2 style="margin-top:0">Accessibility &amp; focus</h2>
     <div class="grid two-col">
       <div>
-        <h3><a href="guides/tts-for-adhd-focus.html">TTS for Focus</a></h3>
+        <h3><a href="/guides/tts-for-adhd-focus.html">TTS for Focus</a></h3>
         <p>Chunking, timers, and pacing strategies tuned for ADHD brains that need steady anchors.</p>
       </div>
       <div>
-        <h3><a href="guides/tts-for-dyslexia-support.html">Dyslexia-Friendly Reading</a></h3>
+        <h3><a href="/guides/tts-for-dyslexia-support.html">Dyslexia-Friendly Reading</a></h3>
         <p>Dual reading tips, pacing ideas, and device setup for readers who benefit from audio support.</p>
       </div>
       <div>
-        <h3><a href="guides/tts-privacy-safety.html">Privacy &amp; Safety</a></h3>
+        <h3><a href="/guides/tts-privacy-safety.html">Privacy &amp; Safety</a></h3>
         <p>Learn what not to paste, why Read‑Aloud uses local voices, and habits that keep sensitive text out of the cloud.</p>
       </div>
     </div>
@@ -88,11 +87,11 @@
     <h2 style="margin-top:0">Language practice</h2>
     <div class="grid two-col">
       <div>
-        <h3><a href="guides/tts-for-language-shadowing.html">Shadowing Practice with TTS</a></h3>
+        <h3><a href="/guides/tts-for-language-shadowing.html">Shadowing Practice with TTS</a></h3>
         <p>Set up scripts, pacing, and progress tracking for language learners who shadow native-like voices.</p>
       </div>
       <div>
-        <h3><a href="guides/tts-for-students.html#multilingual">Multilingual study tips</a></h3>
+        <h3><a href="/guides/tts-for-students.html#multilingual">Multilingual study tips</a></h3>
         <p>Use the student workflow guide’s multilingual section for bilingual homework and pronunciation practice.</p>
       </div>
     </div>
@@ -101,18 +100,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html" aria-current="page">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html" aria-current="page">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Guides are updated as browsers change.</div>
 </footer>

--- a/guides/tts-for-adhd-focus.html
+++ b/guides/tts-for-adhd-focus.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>TTS for Focus: Chunking + Timers + Speed Settings for ADHD Brains</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Use Read‑Aloud with chunking, timers, and pacing to stay engaged. ADHD-friendly routines, device setup, and fail-safes when focus slips." />
+  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-for-adhd-focus.html">
+  <link rel="stylesheet" href="../site.css">
+</head>
+<body>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="../index.html">Home</a>
+      <a href="../app.html">Tool</a>
+      <a href="../guides.html" aria-current="page">Guides</a>
+      <a href="../help.html">Help</a>
+      <a href="../voices.html">Voices</a>
+      <a href="../about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Focus</div>
+  <h1>TTS for Focus: Chunking + Timers + Speed Settings for ADHD Brains</h1>
+  <p class="guide-meta">Built for readers who need structure and short wins. Keep everything in the browser so task switching stays low.</p>
+
+  <section class="card guide-section">
+    <h2>Why TTS helps with ADHD</h2>
+    <p>
+      Audio provides an external pace-maker. When the voice keeps moving, your brain has to follow,
+      reducing the urge to re-read the same line. Pairing Read‑Aloud with a timer gives you a concrete
+      finish line instead of an endless assignment. This guide layers small tactics to keep you engaged
+      without adding complicated apps.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Set up your environment</h2>
+    <ul>
+      <li>Choose a voice that is calm and low-drama. Brighter voices can become irritating during long sessions.</li>
+      <li>Use wired headphones or a single earbud so you can hear your surroundings but still follow the text.</li>
+      <li>Close messaging tabs. If you must keep them open, use full-screen mode on the <a href="../app.html">tool</a> so alerts are hidden.</li>
+      <li>Place a sticky note on your desk with your goal for the block (“Finish Section 3 notes”). Visual anchors help you return after a distraction.</li>
+    </ul>
+  </section>
+
+  <section class="card guide-section">
+    <h2>The 20–20–5 pattern</h2>
+    <ol>
+      <li><strong>20 minutes listening + light notes.</strong> Paste 500–700 words. Keep speed at 1.0×. Write only quick markers (“define term,” “look up chart”).</li>
+      <li><strong>20 minutes review.</strong> Pause the player, answer two recall questions, and rewrite any unclear sections in your own words.</li>
+      <li><strong>5 minute reset.</strong> Stand up, stretch, or drink water. Avoid opening social apps. Restart with a new paste when the timer ends.</li>
+    </ol>
+    <p>
+      Use the <strong>Pause</strong> button instead of Stop so you can resume where you left off if you
+      get interrupted. If you lose the thread, rewind one paragraph and lower speed to 0.9× for a softer re-entry.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Chunking that reduces overwhelm</h2>
+    <p>
+      Long articles trigger avoidance. Break them into named chunks before listening:
+    </p>
+    <ul>
+      <li>Name each chunk (“Background,” “Method,” “Examples”) and write the names in your notebook.</li>
+      <li>Paste only one chunk at a time. Knowing there is an end after a few minutes reduces anxiety.</li>
+      <li>After each chunk, rate your focus from 1–5. If it drops below 3, shorten the next chunk.</li>
+    </ul>
+    <p>
+      If your browser throttles audio after switching tabs, keep Read‑Aloud in the foreground and move
+      your notes to a small side window. The keyboard shortcut <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Y</kbd> returns the cursor to the textarea quickly.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Speed settings that match your task</h2>
+    <ul>
+      <li><strong>0.85–0.95×:</strong> Use for dense reading, new topics, or when you are recovering from a distraction.</li>
+      <li><strong>1.0–1.1×:</strong> Default for steady comprehension. Great for narrative articles and essays.</li>
+      <li><strong>1.2×:</strong> Use only after a first listen to cement concepts while you follow along visually.</li>
+    </ul>
+    <p>
+      Avoid jumping speeds mid-paragraph. Adjust between chunks so your ears can adapt. If the voice
+      sounds robotic at higher speeds, switch to a different system voice that handles faster rates more gracefully.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Fail-safes when focus slips</h2>
+    <ul>
+      <li>When you notice zoning out, pause immediately and write one sentence about the last thing you heard. Resume from that sentence.</li>
+      <li>If you restart the same paragraph more than twice, switch voices. The novelty often resets attention.</li>
+      <li>Keep a “distraction parking lot” in your notes. When a thought pops up, jot it there instead of opening a new tab.</li>
+      <li>Use the <strong>related guides</strong> below to swap routines when today’s setup stops working.</li>
+    </ul>
+  </section>
+
+  <section class="related">
+    <h3>Related guides</h3>
+    <ul>
+      <li><a href="tts-for-students.html">Student Workflow</a></li>
+      <li><a href="tts-for-dyslexia-support.html">Dyslexia-Friendly Reading</a></li>
+      <li><a href="tts-study-loop-templates.html">Study Loop Templates</a></li>
+      <li><a href="tts-privacy-safety.html">Privacy &amp; Safety</a></li>
+    </ul>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html" aria-current="page">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html">Voices</a>
+    <a href="../about.html">About</a>
+    <a href="../contact.html">Contact</a>
+    <a href="../privacy.html">Privacy</a>
+    <a href="../terms.html">Terms</a>
+    <a href="../privacy.html#controls">Privacy settings</a>
+    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="../sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Built for brains that need motion, not friction.</div>
+</footer>
+</body>
+</html>

--- a/guides/tts-for-adhd-focus.html
+++ b/guides/tts-for-adhd-focus.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>TTS for Focus: Chunking + Timers + Speed Settings for ADHD Brains</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Use Read‑Aloud with chunking, timers, and pacing to stay engaged. ADHD-friendly routines, device setup, and fail-safes when focus slips." />
-  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-for-adhd-focus.html">
-  <link rel="stylesheet" href="../site.css">
+  <link rel="canonical" href="https://read-aloud.com/guides/tts-for-adhd-focus.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="../index.html">Home</a>
-      <a href="../app.html">Tool</a>
-      <a href="../guides.html" aria-current="page">Guides</a>
-      <a href="../help.html">Help</a>
-      <a href="../voices.html">Voices</a>
-      <a href="../about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Focus</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> <a href="/guides.html">Guides</a> <span aria-hidden="true">›</span> Focus</div>
   <h1>TTS for Focus: Chunking + Timers + Speed Settings for ADHD Brains</h1>
   <p class="guide-meta">Built for readers who need structure and short wins. Keep everything in the browser so task switching stays low.</p>
 
@@ -46,7 +45,7 @@
     <ul>
       <li>Choose a voice that is calm and low-drama. Brighter voices can become irritating during long sessions.</li>
       <li>Use wired headphones or a single earbud so you can hear your surroundings but still follow the text.</li>
-      <li>Close messaging tabs. If you must keep them open, use full-screen mode on the <a href="../app.html">tool</a> so alerts are hidden.</li>
+      <li>Close messaging tabs. If you must keep them open, use full-screen mode on the <a href="/app.html">tool</a> so alerts are hidden.</li>
       <li>Place a sticky note on your desk with your goal for the block (“Finish Section 3 notes”). Visual anchors help you return after a distraction.</li>
     </ul>
   </section>
@@ -116,18 +115,18 @@
 
 <footer>
   <div>
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html" aria-current="page">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../about.html">About</a>
-    <a href="../contact.html">Contact</a>
-    <a href="../privacy.html">Privacy</a>
-    <a href="../terms.html">Terms</a>
-    <a href="../privacy.html#controls">Privacy settings</a>
-    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="../sitemap.xml">Sitemap</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html" aria-current="page">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/privacy.html#controls">Privacy settings</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Built for brains that need motion, not friction.</div>
 </footer>

--- a/guides/tts-for-dyslexia-support.html
+++ b/guides/tts-for-dyslexia-support.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Dyslexia-Friendly Reading with TTS: Setup, Pacing, and Dual Reading</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Configure Read‑Aloud for dyslexia support: dual reading tips, font choices, pacing, and troubleshooting for system voices." />
+  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-for-dyslexia-support.html">
+  <link rel="stylesheet" href="../site.css">
+</head>
+<body>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="../index.html">Home</a>
+      <a href="../app.html">Tool</a>
+      <a href="../guides.html" aria-current="page">Guides</a>
+      <a href="../help.html">Help</a>
+      <a href="../voices.html">Voices</a>
+      <a href="../about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Dyslexia</div>
+  <h1>Dyslexia-Friendly Reading with TTS: Setup, Pacing, and Dual Reading</h1>
+  <p class="guide-meta">Practical settings for readers who benefit from both audio and text. Focuses on built-in voices so nothing leaves your device.</p>
+
+  <section class="card guide-section">
+    <h2>Start with the right foundation</h2>
+    <p>
+      Read‑Aloud keeps controls simple: paste, choose a voice, and listen. For dyslexia support, combine
+      the tool with visual tweaks in your browser. Increase zoom to 110–125%, use reader mode if
+      available, and choose a sans-serif font. These small changes reduce visual noise while the audio
+      provides pacing.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Dual reading setup</h2>
+    <ul>
+      <li>Paste one paragraph at a time so eyes and ears stay aligned.</li>
+      <li>Keep speed at 0.9–1.0×. Faster rates make word boundaries harder to follow.</li>
+      <li>Use a finger, ruler, or screen mask to track the current line while listening.</li>
+      <li>Highlight keywords in your notes after each paragraph to reinforce spelling and meaning.</li>
+    </ul>
+    <p>
+      If you lose place, press <strong>Pause</strong>, scroll back one line, and press <strong>Resume</strong>. The progress meter helps you return without reloading the page.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Voice choices that reduce fatigue</h2>
+    <p>
+      Softer voices with clear consonants work best. Try multiple voices in the <a href="../app.html">tool</a> and pick the one that keeps your shoulders relaxed after a few minutes. If you switch between reading and writing, keep one voice for reading and another for proofreading to give your brain a fresh cue.
+    </p>
+    <ul>
+      <li>For English learners, pick a regional accent that matches your class materials to avoid extra cognitive load.</li>
+      <li>Lower the speed slightly when encountering dense academic terms.</li>
+      <li>Swap voices midday if you notice irritation—variety can restore attention.</li>
+    </ul>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Pacing strategies</h2>
+    <ul>
+      <li><strong>Short sprints:</strong> Listen for 5–7 minutes, then stop and explain the paragraph to yourself.</li>
+      <li><strong>Echo reading:</strong> Let Read‑Aloud speak a sentence, pause, then read the same sentence aloud yourself. This reinforces rhythm and pronunciation.</li>
+      <li><strong>Keyword anchors:</strong> Before starting, write three words you expect to hear. Check them off as they appear to stay engaged.</li>
+    </ul>
+    <p>
+      Combine these with the <a href="../guides/tts-study-loop-templates.html">study loop templates</a>
+      if you want a structured timer alongside the player.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>When text formatting gets messy</h2>
+    <p>
+      PDFs with columns or headers can read strangely. Before listening, paste the text into a plain
+      document and remove headers or page numbers. If words run together, add a blank line between
+      paragraphs so the pause is obvious in audio. On mobile, rotate the device to landscape for a wider
+      view and larger font.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Support plan for school accommodations</h2>
+    <p>
+      If you use Read‑Aloud as part of an accommodation plan, prepare a quick proof-of-concept for your
+      teacher or support coordinator:
+    </p>
+    <ul>
+      <li>Show that the tool keeps data local (no uploads) and can run without an account.</li>
+      <li>Demonstrate a 30-second clip with the default voice and the voice you prefer.</li>
+      <li>Explain how you pause to take notes and how the progress meter keeps you on track.</li>
+    </ul>
+    <p>
+      Keep a backup browser installed (Chrome plus Edge or Safari) in case one blocks voices during
+      testing. The <a href="../help.html">Help Center</a> includes more troubleshooting steps if audio ever stops mid-assessment.
+    </p>
+  </section>
+
+  <section class="related">
+    <h3>Related guides</h3>
+    <ul>
+      <li><a href="tts-for-adhd-focus.html">TTS for Focus</a></li>
+      <li><a href="tts-voice-selection.html">How to Choose the Best Voice</a></li>
+      <li><a href="tts-privacy-safety.html">Privacy &amp; Safety</a></li>
+      <li><a href="tts-study-loop-templates.html">Study Loop Templates</a></li>
+    </ul>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html" aria-current="page">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html">Voices</a>
+    <a href="../about.html">About</a>
+    <a href="../contact.html">Contact</a>
+    <a href="../privacy.html">Privacy</a>
+    <a href="../terms.html">Terms</a>
+    <a href="../privacy.html#controls">Privacy settings</a>
+    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="../sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Audio pacing designed to support dual reading.</div>
+</footer>
+</body>
+</html>

--- a/guides/tts-for-dyslexia-support.html
+++ b/guides/tts-for-dyslexia-support.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Dyslexia-Friendly Reading with TTS: Setup, Pacing, and Dual Reading</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Configure Read‑Aloud for dyslexia support: dual reading tips, font choices, pacing, and troubleshooting for system voices." />
-  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-for-dyslexia-support.html">
-  <link rel="stylesheet" href="../site.css">
+  <link rel="canonical" href="https://read-aloud.com/guides/tts-for-dyslexia-support.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="../index.html">Home</a>
-      <a href="../app.html">Tool</a>
-      <a href="../guides.html" aria-current="page">Guides</a>
-      <a href="../help.html">Help</a>
-      <a href="../voices.html">Voices</a>
-      <a href="../about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Dyslexia</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> <a href="/guides.html">Guides</a> <span aria-hidden="true">›</span> Dyslexia</div>
   <h1>Dyslexia-Friendly Reading with TTS: Setup, Pacing, and Dual Reading</h1>
   <p class="guide-meta">Practical settings for readers who benefit from both audio and text. Focuses on built-in voices so nothing leaves your device.</p>
 
@@ -57,7 +56,7 @@
   <section class="card guide-section">
     <h2>Voice choices that reduce fatigue</h2>
     <p>
-      Softer voices with clear consonants work best. Try multiple voices in the <a href="../app.html">tool</a> and pick the one that keeps your shoulders relaxed after a few minutes. If you switch between reading and writing, keep one voice for reading and another for proofreading to give your brain a fresh cue.
+      Softer voices with clear consonants work best. Try multiple voices in the <a href="/app.html">tool</a> and pick the one that keeps your shoulders relaxed after a few minutes. If you switch between reading and writing, keep one voice for reading and another for proofreading to give your brain a fresh cue.
     </p>
     <ul>
       <li>For English learners, pick a regional accent that matches your class materials to avoid extra cognitive load.</li>
@@ -74,7 +73,7 @@
       <li><strong>Keyword anchors:</strong> Before starting, write three words you expect to hear. Check them off as they appear to stay engaged.</li>
     </ul>
     <p>
-      Combine these with the <a href="../guides/tts-study-loop-templates.html">study loop templates</a>
+      Combine these with the <a href="/guides/tts-study-loop-templates.html">study loop templates</a>
       if you want a structured timer alongside the player.
     </p>
   </section>
@@ -102,7 +101,7 @@
     </ul>
     <p>
       Keep a backup browser installed (Chrome plus Edge or Safari) in case one blocks voices during
-      testing. The <a href="../help.html">Help Center</a> includes more troubleshooting steps if audio ever stops mid-assessment.
+      testing. The <a href="/help.html">Help Center</a> includes more troubleshooting steps if audio ever stops mid-assessment.
     </p>
   </section>
 
@@ -119,18 +118,18 @@
 
 <footer>
   <div>
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html" aria-current="page">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../about.html">About</a>
-    <a href="../contact.html">Contact</a>
-    <a href="../privacy.html">Privacy</a>
-    <a href="../terms.html">Terms</a>
-    <a href="../privacy.html#controls">Privacy settings</a>
-    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="../sitemap.xml">Sitemap</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html" aria-current="page">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/privacy.html#controls">Privacy settings</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Audio pacing designed to support dual reading.</div>
 </footer>

--- a/guides/tts-for-language-shadowing.html
+++ b/guides/tts-for-language-shadowing.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Shadowing Practice with TTS: Scripts, Routines, and How to Track Progress</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Build a language shadowing routine with Read‑Aloud: scripts, pacing, recording tips, and progress tracking using system voices." />
-  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-for-language-shadowing.html">
-  <link rel="stylesheet" href="../site.css">
+  <link rel="canonical" href="https://read-aloud.com/guides/tts-for-language-shadowing.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="../index.html">Home</a>
-      <a href="../app.html">Tool</a>
-      <a href="../guides.html" aria-current="page">Guides</a>
-      <a href="../help.html">Help</a>
-      <a href="../voices.html">Voices</a>
-      <a href="../about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Shadowing</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> <a href="/guides.html">Guides</a> <span aria-hidden="true">›</span> Shadowing</div>
   <h1>Shadowing Practice with TTS: Scripts, Routines, and How to Track Progress</h1>
   <p class="guide-meta">For language learners who want consistent pronunciation practice without extra apps. Works with any system voice installed on your device.</p>
 
@@ -36,7 +35,7 @@
     <p>
       Choose 150–250 word scripts that mirror real conversations: news blurbs, short dialogues, or
       paragraphs from graded readers. Avoid tongue twisters at first; clarity matters more than speed.
-      Paste one script at a time into the <a href="../app.html">tool</a> and label your notebook with the script title and date.
+      Paste one script at a time into the <a href="/app.html">tool</a> and label your notebook with the script title and date.
     </p>
   </section>
 
@@ -60,7 +59,7 @@
     <p>
       Pick a voice that matches your target accent. Many system voices include region labels (US, UK,
       AU, ES-MX, FR-CA). If you are practicing tonal languages, choose a clear, steady voice and slow to
-      0.9× to hear tone contours. The <a href="../voices.html">Voice Gallery</a> lists how to install
+      0.9× to hear tone contours. The <a href="/voices.html">Voice Gallery</a> lists how to install
       additional voices on each platform.
     </p>
     <p>
@@ -102,18 +101,18 @@
 
 <footer>
   <div>
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html" aria-current="page">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../about.html">About</a>
-    <a href="../contact.html">Contact</a>
-    <a href="../privacy.html">Privacy</a>
-    <a href="../terms.html">Terms</a>
-    <a href="../privacy.html#controls">Privacy settings</a>
-    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="../sitemap.xml">Sitemap</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html" aria-current="page">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/privacy.html#controls">Privacy settings</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Practice with voices that match your target accent.</div>
 </footer>

--- a/guides/tts-for-language-shadowing.html
+++ b/guides/tts-for-language-shadowing.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Shadowing Practice with TTS: Scripts, Routines, and How to Track Progress</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Build a language shadowing routine with Read‑Aloud: scripts, pacing, recording tips, and progress tracking using system voices." />
+  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-for-language-shadowing.html">
+  <link rel="stylesheet" href="../site.css">
+</head>
+<body>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="../index.html">Home</a>
+      <a href="../app.html">Tool</a>
+      <a href="../guides.html" aria-current="page">Guides</a>
+      <a href="../help.html">Help</a>
+      <a href="../voices.html">Voices</a>
+      <a href="../about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Shadowing</div>
+  <h1>Shadowing Practice with TTS: Scripts, Routines, and How to Track Progress</h1>
+  <p class="guide-meta">For language learners who want consistent pronunciation practice without extra apps. Works with any system voice installed on your device.</p>
+
+  <section class="card guide-section">
+    <h2>Pick scripts that actually teach you</h2>
+    <p>
+      Choose 150–250 word scripts that mirror real conversations: news blurbs, short dialogues, or
+      paragraphs from graded readers. Avoid tongue twisters at first; clarity matters more than speed.
+      Paste one script at a time into the <a href="../app.html">tool</a> and label your notebook with the script title and date.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Shadowing routine (15 minutes)</h2>
+    <ol>
+      <li><strong>Listen cold:</strong> Play the script once at normal speed with no speaking. Circle words you do not recognize.</li>
+      <li><strong>Slow mimic:</strong> Lower speed to 0.85–0.9×. Speak quietly with the voice, matching rhythm and intonation.</li>
+      <li><strong>Normal pace:</strong> Return to 1.0× and shadow again. Focus on linking words and matching pauses.</li>
+      <li><strong>Record yourself:</strong> Use your phone or laptop recorder for a 20–30 second snippet. Compare to the system voice and note differences.</li>
+      <li><strong>Finish fast:</strong> If you feel comfortable, try 1.1× to test your breath control. If it feels sloppy, drop back to 1.0× and repeat.</li>
+    </ol>
+    <p>
+      Keep each routine short so you stop before fatigue sets in. Two routines per day beat one long
+      session you abandon mid-week.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Choosing the right voice</h2>
+    <p>
+      Pick a voice that matches your target accent. Many system voices include region labels (US, UK,
+      AU, ES-MX, FR-CA). If you are practicing tonal languages, choose a clear, steady voice and slow to
+      0.9× to hear tone contours. The <a href="../voices.html">Voice Gallery</a> lists how to install
+      additional voices on each platform.
+    </p>
+    <p>
+      If your device only offers one voice, alternate between browsers. Chrome and Edge sometimes expose
+      different voices even on the same system.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Track progress without spreadsheets</h2>
+    <ul>
+      <li>Create a simple log in your notes app: date, script title, speed used, and one thing to improve.</li>
+      <li>Record the same script once a week. Listen to week-old recordings to hear changes in pacing and pronunciation.</li>
+      <li>Set a monthly goal such as “shadow 20 scripts” or “hold 1.0× speed without stumbling.”</li>
+      <li>Use the progress meter in Read‑Aloud as a built-in timer—finish the bar, then rest.</li>
+    </ul>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Common issues and fixes</h2>
+    <ul>
+      <li><strong>Voice too fast even at 1.0×:</strong> Switch to a different voice or browser; some voices are recorded faster.</li>
+      <li><strong>Background noise in recordings:</strong> Use wired headphones with a built-in mic or move closer to the device.</li>
+      <li><strong>Words run together:</strong> Insert blank lines between sentences in the textarea so pauses are clearer.</li>
+      <li><strong>Stamina drops mid-script:</strong> Break the script into two halves and shadow separately.</li>
+    </ul>
+  </section>
+
+  <section class="related">
+    <h3>Related guides</h3>
+    <ul>
+      <li><a href="tts-voice-selection.html">How to Choose the Best Voice</a></li>
+      <li><a href="tts-for-students.html#multilingual">Multilingual Study Tips</a></li>
+      <li><a href="tts-privacy-safety.html">Privacy &amp; Safety</a></li>
+      <li><a href="tts-study-loop-templates.html">Study Loop Templates</a></li>
+    </ul>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html" aria-current="page">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html">Voices</a>
+    <a href="../about.html">About</a>
+    <a href="../contact.html">Contact</a>
+    <a href="../privacy.html">Privacy</a>
+    <a href="../terms.html">Terms</a>
+    <a href="../privacy.html#controls">Privacy settings</a>
+    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="../sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Practice with voices that match your target accent.</div>
+</footer>
+</body>
+</html>

--- a/guides/tts-for-students.html
+++ b/guides/tts-for-students.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-SVGML1VGPG');
+  </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Text-to-Speech for Students: A Practical Workflow That Actually Improves Grades</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Step-by-step Read‑Aloud workflow for students: setup, pacing, note-taking, active recall, and troubleshooting for school devices." />
+  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-for-students.html">
+  <link rel="stylesheet" href="../site.css">
+</head>
+<body>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="../index.html">Home</a>
+      <a href="../app.html">Tool</a>
+      <a href="../guides.html" aria-current="page">Guides</a>
+      <a href="../help.html">Help</a>
+      <a href="../voices.html">Voices</a>
+      <a href="../about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Students</div>
+  <h1>Text-to-Speech for Students: A Practical Workflow That Actually Improves Grades</h1>
+  <p class="guide-meta">Applies to laptops, tablets, and school-managed devices. Uses the Read‑Aloud web tool with system voices.</p>
+
+  <section class="card guide-section">
+    <h2>Why listen instead of only reading?</h2>
+    <p>
+      Hearing your own notes exposes gaps you cannot see when skimming. Read‑Aloud keeps everything in
+      the browser so you can move between textbooks, PDFs, and LMS pages without extra apps. Audio
+      doubles as an accountability timer: if you drift, the progress meter shows exactly where you
+      stopped. This guide gives you a repeatable routine you can use all semester.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Set up once for the whole term</h2>
+    <ul>
+      <li>Open <a href="../app.html">read-aloud.com/app</a> and run a 10-second test clip. This grants the tab audio permission on your device.</li>
+      <li>Select a voice you can tolerate for 20+ minutes. Natural voices on macOS/iOS or the newest Windows packs reduce fatigue; see the <a href="../voices.html">Voice Gallery</a> for install tips.</li>
+      <li>Pick a default speed: start at 1.0×, then nudge to 1.1× for lighter reading or 0.9× for dense science text.</li>
+      <li>Bookmark the page and pin the tab. On Chromebooks, right-click the tab and choose “Pin” so it loads quickly each study session.</li>
+    </ul>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Daily workflow (45–60 minute block)</h2>
+    <ol>
+      <li><strong>Gather sources:</strong> Copy the section you need from your LMS or PDF. Aim for 500–800 words (about 3–5 minutes of audio).</li>
+      <li><strong>Paste and preview:</strong> Drop it into the text box and scan for formatting issues. Remove duplicate headers or page numbers that distract while listening.</li>
+      <li><strong>Start with a timer:</strong> Press <em>Start</em> and start a 15–20 minute timer. The goal is one uninterrupted listen. If you must pause, use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> so you can resume without losing place.</li>
+      <li><strong>Take “margin” notes:</strong> Keep a small notepad. When you hear a key fact, jot a two-word cue and the progress percent from the meter.</li>
+      <li><strong>Active recall:</strong> After the clip ends, close the tab with your notes and explain the section out loud or in writing. Only then check the text again.</li>
+      <li><strong>Repeat with the next section:</strong> Pace yourself through two or three sections, then take a five-minute break before starting a new block.</li>
+    </ol>
+    <p>
+      This rhythm keeps listens short enough to stay engaged and gives you time to encode the material
+      before moving on. If you fall behind, shorten sections to 300–400 words until you rebuild focus.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Note-taking patterns that pair well with audio</h2>
+    <p>Try one of these approaches to keep listening active:</p>
+    <ul>
+      <li><strong>Question-first:</strong> Before pressing Start, write three questions you expect the passage to answer. Pause only when you hear the answer and write it down.</li>
+      <li><strong>Signal words:</strong> Listen for “because,” “for example,” and “however.” When you hear them, jot the clause that follows to build a cause/effect outline.</li>
+      <li><strong>Vocabulary loop:</strong> For language classes, pause after each new term, repeat it aloud, then resume. Add phonetic hints in your notebook.</li>
+    </ul>
+    <p>
+      If you prefer typing, open a split-screen with your notes app on the right and Read‑Aloud on the
+      left. Use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Y</kbd> to jump the cursor back into the textarea when you need to paste the next section.
+    </p>
+  </section>
+
+  <section class="card guide-section" id="multilingual">
+    <h2>Multilingual and ESL homework</h2>
+    <p>
+      Switch the <strong>Language</strong> dropdown to match the text you are pasting. This filters the
+      voice list to voices that pronounce that language correctly. For bilingual assignments, keep two
+      windows open with different language settings and use the Resume button to alternate between them.
+    </p>
+    <ul>
+      <li>For pronunciation practice, slow speed to 0.8× and shadow a paragraph twice before moving on.</li>
+      <li>For comprehension, listen once at 1.0× then again at 1.2× while following along visually. The faster repeat cements rhythm.</li>
+      <li>Record tricky sentences in your notes with the voice name you used so you can replay them later.</li>
+    </ul>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Troubleshooting during exams or tight deadlines</h2>
+    <p>
+      School devices sometimes lock down audio. If voices disappear right before an exam, open the
+      <a href="../help.html#empty-voices">missing voice checklist</a> and try another browser. If audio stutters, reduce speed to 0.9× and paste shorter segments. When Wi‑Fi is unstable, keep the tab open and avoid refreshing; the tool can continue speaking offline if the voice was already loaded.
+    </p>
+    <p>
+      If nothing helps, fall back to a backup plan: download a free system voice in Settings, reboot,
+      and replay the section. Always keep a printed or offline copy of critical instructions so you are
+      not blocked by a flaky network.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Checklist to run before each study week</h2>
+    <ul>
+      <li>Confirm your default voice still sounds natural after any OS updates.</li>
+      <li>Test the keyboard shortcuts after reopening the browser.</li>
+      <li>Prepare a fresh page in your notes app labeled with the course and week number.</li>
+      <li>Bookmark the <a href="../guides/tts-study-loop-templates.html">study loop templates</a> you plan to use.</li>
+      <li>Charge headphones and keep a wired pair as backup to avoid Bluetooth dropouts.</li>
+    </ul>
+  </section>
+
+  <section class="related">
+    <h3>Related guides</h3>
+    <ul>
+      <li><a href="tts-study-loop-templates.html">Copy/Paste Study Loop Templates</a></li>
+      <li><a href="tts-for-adhd-focus.html">TTS for Focus</a></li>
+      <li><a href="tts-voice-selection.html">How to Choose the Best Voice</a></li>
+      <li><a href="tts-privacy-safety.html">Privacy &amp; Safety</a></li>
+    </ul>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html" aria-current="page">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html">Voices</a>
+    <a href="../about.html">About</a>
+    <a href="../contact.html">Contact</a>
+    <a href="../privacy.html">Privacy</a>
+    <a href="../terms.html">Terms</a>
+    <a href="../privacy.html#controls">Privacy settings</a>
+    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="../sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Built for students who need reliable listening routines.</div>
+</footer>
+</body>
+</html>

--- a/guides/tts-for-students.html
+++ b/guides/tts-for-students.html
@@ -6,31 +6,30 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-SVGML1VGPG');
   </script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Text-to-Speech for Students: A Practical Workflow That Actually Improves Grades</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Step-by-step Read‑Aloud workflow for students: setup, pacing, note-taking, active recall, and troubleshooting for school devices." />
-  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-for-students.html">
-  <link rel="stylesheet" href="../site.css">
+  <link rel="canonical" href="https://read-aloud.com/guides/tts-for-students.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="../index.html">Home</a>
-      <a href="../app.html">Tool</a>
-      <a href="../guides.html" aria-current="page">Guides</a>
-      <a href="../help.html">Help</a>
-      <a href="../voices.html">Voices</a>
-      <a href="../about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Students</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> <a href="/guides.html">Guides</a> <span aria-hidden="true">›</span> Students</div>
   <h1>Text-to-Speech for Students: A Practical Workflow That Actually Improves Grades</h1>
   <p class="guide-meta">Applies to laptops, tablets, and school-managed devices. Uses the Read‑Aloud web tool with system voices.</p>
 
@@ -47,8 +46,8 @@
   <section class="card guide-section">
     <h2>Set up once for the whole term</h2>
     <ul>
-      <li>Open <a href="../app.html">read-aloud.com/app</a> and run a 10-second test clip. This grants the tab audio permission on your device.</li>
-      <li>Select a voice you can tolerate for 20+ minutes. Natural voices on macOS/iOS or the newest Windows packs reduce fatigue; see the <a href="../voices.html">Voice Gallery</a> for install tips.</li>
+      <li>Open <a href="/app.html">read-aloud.com/app</a> and run a 10-second test clip. This grants the tab audio permission on your device.</li>
+      <li>Select a voice you can tolerate for 20+ minutes. Natural voices on macOS/iOS or the newest Windows packs reduce fatigue; see the <a href="/voices.html">Voice Gallery</a> for install tips.</li>
       <li>Pick a default speed: start at 1.0×, then nudge to 1.1× for lighter reading or 0.9× for dense science text.</li>
       <li>Bookmark the page and pin the tab. On Chromebooks, right-click the tab and choose “Pin” so it loads quickly each study session.</li>
     </ul>
@@ -102,7 +101,7 @@
     <h2>Troubleshooting during exams or tight deadlines</h2>
     <p>
       School devices sometimes lock down audio. If voices disappear right before an exam, open the
-      <a href="../help.html#empty-voices">missing voice checklist</a> and try another browser. If audio stutters, reduce speed to 0.9× and paste shorter segments. When Wi‑Fi is unstable, keep the tab open and avoid refreshing; the tool can continue speaking offline if the voice was already loaded.
+      <a href="/help.html#empty-voices">missing voice checklist</a> and try another browser. If audio stutters, reduce speed to 0.9× and paste shorter segments. When Wi‑Fi is unstable, keep the tab open and avoid refreshing; the tool can continue speaking offline if the voice was already loaded.
     </p>
     <p>
       If nothing helps, fall back to a backup plan: download a free system voice in Settings, reboot,
@@ -117,7 +116,7 @@
       <li>Confirm your default voice still sounds natural after any OS updates.</li>
       <li>Test the keyboard shortcuts after reopening the browser.</li>
       <li>Prepare a fresh page in your notes app labeled with the course and week number.</li>
-      <li>Bookmark the <a href="../guides/tts-study-loop-templates.html">study loop templates</a> you plan to use.</li>
+      <li>Bookmark the <a href="/guides/tts-study-loop-templates.html">study loop templates</a> you plan to use.</li>
       <li>Charge headphones and keep a wired pair as backup to avoid Bluetooth dropouts.</li>
     </ul>
   </section>
@@ -135,18 +134,18 @@
 
 <footer>
   <div>
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html" aria-current="page">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../about.html">About</a>
-    <a href="../contact.html">Contact</a>
-    <a href="../privacy.html">Privacy</a>
-    <a href="../terms.html">Terms</a>
-    <a href="../privacy.html#controls">Privacy settings</a>
-    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="../sitemap.xml">Sitemap</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html" aria-current="page">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/privacy.html#controls">Privacy settings</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Built for students who need reliable listening routines.</div>
 </footer>

--- a/guides/tts-for-writers.html
+++ b/guides/tts-for-writers.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Text-to-Speech for Writers: A Proofreading Process That Finds the Mistakes Your Eyes Miss</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Use Read‑Aloud to proofread drafts by ear: pacing, voice selection, markup habits, and checklists that catch rhythm issues and missing words." />
+  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-for-writers.html">
+  <link rel="stylesheet" href="../site.css">
+</head>
+<body>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="../index.html">Home</a>
+      <a href="../app.html">Tool</a>
+      <a href="../guides.html" aria-current="page">Guides</a>
+      <a href="../help.html">Help</a>
+      <a href="../voices.html">Voices</a>
+      <a href="../about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Writers</div>
+  <h1>Text-to-Speech for Writers: A Proofreading Process That Finds the Mistakes Your Eyes Miss</h1>
+  <p class="guide-meta">Great for essays, newsletters, reports, and UX copy. Uses Read‑Aloud with local voices so your drafts stay private.</p>
+
+  <section class="card guide-section">
+    <h2>Why listen while editing?</h2>
+    <p>
+      Reading aloud forces rhythm and reveals missing words, doubled phrases, and awkward cadence. The
+      progress meter keeps you honest; if your mind drifts at 40%, rewind a paragraph and fix the
+      distraction. Listening also separates your brain from the visual layout, making tone and pacing
+      issues stand out.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Prep your draft for audio</h2>
+    <ul>
+      <li>Copy the section you want to edit (500–1,000 words) into the <a href="../app.html">tool</a>. If you write in Markdown, leave the headings—they help you navigate.</li>
+      <li>Choose a neutral voice that contrasts with your own. Writers often prefer a different gender or accent so mistakes sound foreign and obvious.</li>
+      <li>Set speed to 0.95× for first passes. Increase to 1.1× for later polishing once big issues are fixed.</li>
+      <li>Close other tabs that make sound. Clean audio reduces fatigue during long sessions.</li>
+    </ul>
+  </section>
+
+  <section class="card guide-section">
+    <h2>The three-pass proofreading loop</h2>
+    <ol>
+      <li><strong>Structure pass:</strong> Listen without touching the keyboard. Mark only headline moves—“move paragraph,” “swap order,” “cut example.” Use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> to pause when you need to jot a note.</li>
+      <li><strong>Clarity pass:</strong> Paste a single paragraph at a time. After each listen, rewrite the sentence that made you wince. Adjust speed to 1.0× so emphasis stays natural.</li>
+      <li><strong>Polish pass:</strong> Increase speed to 1.2×. Fast playback surfaces extra words and filler (“just,” “very,” “actually”). Trim them immediately, then replay at normal speed.</li>
+    </ol>
+    <p>
+      Keep sessions short—20 minutes of audio followed by a five-minute break. The tool’s progress bar
+      helps you stop at a natural break instead of mid-sentence.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Markup habits that save time</h2>
+    <p>
+      Instead of editing inside the player, keep your main draft open in another window and use a quick
+      shorthand as you listen:
+    </p>
+    <ul>
+      <li><strong>[awk]</strong> for awkward pacing or emphasis.</li>
+      <li><strong>[rep]</strong> for repeated words or phrases.</li>
+      <li><strong>[cut]</strong> for sentences that add no meaning.</li>
+      <li><strong>[ex]</strong> when you owe the reader an example or data point.</li>
+    </ul>
+    <p>
+      After the listen, jump back to your draft and resolve the tags in order. This keeps listening flow
+      smooth and avoids constant context switching.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Voice selection for editing moods</h2>
+    <p>
+      Match the voice to the job:
+    </p>
+    <ul>
+      <li><strong>Newsletters and marketing copy:</strong> Choose a bright, conversational voice at 1.05× to mimic a presenter.</li>
+      <li><strong>Technical docs:</strong> Pick a calm, neutral voice. Slow to 0.9× when listening for exact terminology and API names.</li>
+      <li><strong>Longform essays:</strong> Use two voices—one for drafting, another for the final pass. Switching voices refreshes your ears and exposes monotony.</li>
+    </ul>
+    <p>
+      If you are editing in a second language, filter by language in the dropdown so proper nouns are pronounced correctly. The <a href="../voices.html">Voice Gallery</a> lists platform-specific options.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>When something sounds “off”</h2>
+    <p>
+      If a sentence lands flat, ask these questions after pausing:
+    </p>
+    <ul>
+      <li>Did two adjacent sentences start the same way? Combine or vary openings.</li>
+      <li>Is the verb buried? Swap to a stronger verb and remove helper phrases like “in order to.”</li>
+      <li>Does the example arrive too late? Move it closer to the claim so the audio cadence makes sense.</li>
+      <li>Are you overusing parentheses or em dashes? Break into two sentences to simplify the spoken rhythm.</li>
+    </ul>
+    <p>
+      Replay after each change. If the fix works, note it in a personal editing checklist so you can
+      avoid repeating the same mistake next time.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Publishing checklist</h2>
+    <ul>
+      <li>Listen once at normal speed without stopping to catch lingering typos.</li>
+      <li>Scan headings and bullets visually to confirm they match the spoken sequence.</li>
+      <li>Run a short listen (100–150 words) on mobile to ensure the layout is readable while you track along.</li>
+      <li>Remove any placeholder tags you added during markup (<strong>[awk]</strong>, <strong>[ex]</strong>, etc.).</li>
+      <li>Save your preferred voice and speed in a sticky note so the next session starts faster.</li>
+    </ul>
+  </section>
+
+  <section class="related">
+    <h3>Related guides</h3>
+    <ul>
+      <li><a href="tts-voice-selection.html">How to Choose the Best Voice</a></li>
+      <li><a href="tts-privacy-safety.html">Privacy &amp; Safety</a></li>
+      <li><a href="tts-for-students.html">Student Workflow (for research-heavy writing)</a></li>
+      <li><a href="tts-study-loop-templates.html">Study Loop Templates</a></li>
+    </ul>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html" aria-current="page">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html">Voices</a>
+    <a href="../about.html">About</a>
+    <a href="../contact.html">Contact</a>
+    <a href="../privacy.html">Privacy</a>
+    <a href="../terms.html">Terms</a>
+    <a href="../privacy.html#controls">Privacy settings</a>
+    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="../sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Proofread by ear without giving up privacy.</div>
+</footer>
+</body>
+</html>

--- a/guides/tts-for-writers.html
+++ b/guides/tts-for-writers.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Text-to-Speech for Writers: A Proofreading Process That Finds the Mistakes Your Eyes Miss</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Use Read‑Aloud to proofread drafts by ear: pacing, voice selection, markup habits, and checklists that catch rhythm issues and missing words." />
-  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-for-writers.html">
-  <link rel="stylesheet" href="../site.css">
+  <link rel="canonical" href="https://read-aloud.com/guides/tts-for-writers.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="../index.html">Home</a>
-      <a href="../app.html">Tool</a>
-      <a href="../guides.html" aria-current="page">Guides</a>
-      <a href="../help.html">Help</a>
-      <a href="../voices.html">Voices</a>
-      <a href="../about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Writers</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> <a href="/guides.html">Guides</a> <span aria-hidden="true">›</span> Writers</div>
   <h1>Text-to-Speech for Writers: A Proofreading Process That Finds the Mistakes Your Eyes Miss</h1>
   <p class="guide-meta">Great for essays, newsletters, reports, and UX copy. Uses Read‑Aloud with local voices so your drafts stay private.</p>
 
@@ -44,7 +43,7 @@
   <section class="card guide-section">
     <h2>Prep your draft for audio</h2>
     <ul>
-      <li>Copy the section you want to edit (500–1,000 words) into the <a href="../app.html">tool</a>. If you write in Markdown, leave the headings—they help you navigate.</li>
+      <li>Copy the section you want to edit (500–1,000 words) into the <a href="/app.html">tool</a>. If you write in Markdown, leave the headings—they help you navigate.</li>
       <li>Choose a neutral voice that contrasts with your own. Writers often prefer a different gender or accent so mistakes sound foreign and obvious.</li>
       <li>Set speed to 0.95× for first passes. Increase to 1.1× for later polishing once big issues are fixed.</li>
       <li>Close other tabs that make sound. Clean audio reduces fatigue during long sessions.</li>
@@ -93,7 +92,7 @@
       <li><strong>Longform essays:</strong> Use two voices—one for drafting, another for the final pass. Switching voices refreshes your ears and exposes monotony.</li>
     </ul>
     <p>
-      If you are editing in a second language, filter by language in the dropdown so proper nouns are pronounced correctly. The <a href="../voices.html">Voice Gallery</a> lists platform-specific options.
+      If you are editing in a second language, filter by language in the dropdown so proper nouns are pronounced correctly. The <a href="/voices.html">Voice Gallery</a> lists platform-specific options.
     </p>
   </section>
 
@@ -138,18 +137,18 @@
 
 <footer>
   <div>
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html" aria-current="page">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../about.html">About</a>
-    <a href="../contact.html">Contact</a>
-    <a href="../privacy.html">Privacy</a>
-    <a href="../terms.html">Terms</a>
-    <a href="../privacy.html#controls">Privacy settings</a>
-    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="../sitemap.xml">Sitemap</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html" aria-current="page">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/privacy.html#controls">Privacy settings</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Proofread by ear without giving up privacy.</div>
 </footer>

--- a/guides/tts-privacy-safety.html
+++ b/guides/tts-privacy-safety.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Privacy &amp; Safety: What Not to Paste, How Local Voices Work, and Safer Habits</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Keep text private while using Read‑Aloud. Learn what not to paste, how local system voices work, and safer habits for sensitive content." />
-  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-privacy-safety.html">
-  <link rel="stylesheet" href="../site.css">
+  <link rel="canonical" href="https://read-aloud.com/guides/tts-privacy-safety.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="../index.html">Home</a>
-      <a href="../app.html">Tool</a>
-      <a href="../guides.html" aria-current="page">Guides</a>
-      <a href="../help.html">Help</a>
-      <a href="../voices.html">Voices</a>
-      <a href="../about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Privacy &amp; Safety</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> <a href="/guides.html">Guides</a> <span aria-hidden="true">›</span> Privacy &amp; Safety</div>
   <h1>Privacy &amp; Safety: What Not to Paste, How Local Voices Work, and Safer Habits</h1>
   <p class="guide-meta">Read‑Aloud runs entirely in your browser, but privacy still depends on smart habits. Use this guide to decide what is safe to paste and how to reduce risk.</p>
 
@@ -58,7 +57,7 @@
     <h2>Safer habits while listening</h2>
     <ul>
       <li>Use a private window if you share a device. Close the tab when finished.</li>
-      <li>Keep the <a href="../app.html">tool</a> in the foreground to prevent screenshots from other apps.</li>
+      <li>Keep the <a href="/app.html">tool</a> in the foreground to prevent screenshots from other apps.</li>
       <li>Use wired headphones in public spaces so audio is not overheard.</li>
       <li>When copying from a website, strip tracking parameters from URLs before saving notes.</li>
     </ul>
@@ -79,7 +78,7 @@
     <p>
       In classrooms or libraries, log out of personal accounts and avoid pasting private text. If
       Read‑Aloud is part of an accommodation, coordinate with your instructor so they know audio is for
-      accessibility, not distraction. Use the <a href="../help.html">Help Center</a> if voices are locked down on managed devices.
+      accessibility, not distraction. Use the <a href="/help.html">Help Center</a> if voices are locked down on managed devices.
     </p>
   </section>
 
@@ -87,7 +86,7 @@
     <h2>Data retention</h2>
     <p>
       Read‑Aloud stores no pasted text. Your browser may keep the page in memory until you close it. For
-      extra assurance, refresh the tab or close the browser after a session. Ads run only on content pages like this guide; the <a href="../app.html">tool</a> intentionally avoids loading ad scripts next to user text.
+      extra assurance, refresh the tab or close the browser after a session. Ads run only on content pages like this guide; the <a href="/app.html">tool</a> intentionally avoids loading ad scripts next to user text.
     </p>
   </section>
 
@@ -104,18 +103,18 @@
 
 <footer>
   <div>
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html" aria-current="page">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../about.html">About</a>
-    <a href="../contact.html">Contact</a>
-    <a href="../privacy.html">Privacy</a>
-    <a href="../terms.html">Terms</a>
-    <a href="../privacy.html#controls">Privacy settings</a>
-    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="../sitemap.xml">Sitemap</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html" aria-current="page">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/privacy.html#controls">Privacy settings</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Privacy-first by design.</div>
 </footer>

--- a/guides/tts-privacy-safety.html
+++ b/guides/tts-privacy-safety.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Privacy &amp; Safety: What Not to Paste, How Local Voices Work, and Safer Habits</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Keep text private while using Read‑Aloud. Learn what not to paste, how local system voices work, and safer habits for sensitive content." />
+  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-privacy-safety.html">
+  <link rel="stylesheet" href="../site.css">
+</head>
+<body>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="../index.html">Home</a>
+      <a href="../app.html">Tool</a>
+      <a href="../guides.html" aria-current="page">Guides</a>
+      <a href="../help.html">Help</a>
+      <a href="../voices.html">Voices</a>
+      <a href="../about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Privacy &amp; Safety</div>
+  <h1>Privacy &amp; Safety: What Not to Paste, How Local Voices Work, and Safer Habits</h1>
+  <p class="guide-meta">Read‑Aloud runs entirely in your browser, but privacy still depends on smart habits. Use this guide to decide what is safe to paste and how to reduce risk.</p>
+
+  <section class="card guide-section">
+    <h2>Local voices, not cloud streaming</h2>
+    <p>
+      Read‑Aloud asks your browser for system voices and queues text through the Speech Synthesis API. No
+      text is uploaded to our servers or to cloud TTS providers. Analytics track page visits only. This
+      design keeps your documents local and works even when offline once the page is loaded.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>What not to paste</h2>
+    <ul>
+      <li>Unredacted medical notes or protected health information.</li>
+      <li>Student records with names, IDs, or grades.</li>
+      <li>Contracts containing confidential client terms.</li>
+      <li>Passwords, API keys, or private links.</li>
+    </ul>
+    <p>
+      If you must listen to sensitive material, replace names with placeholders before pasting and delete
+      the text after listening. Avoid using shared or public computers for confidential work.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Safer habits while listening</h2>
+    <ul>
+      <li>Use a private window if you share a device. Close the tab when finished.</li>
+      <li>Keep the <a href="../app.html">tool</a> in the foreground to prevent screenshots from other apps.</li>
+      <li>Use wired headphones in public spaces so audio is not overheard.</li>
+      <li>When copying from a website, strip tracking parameters from URLs before saving notes.</li>
+    </ul>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Backing up without exporting audio</h2>
+    <p>
+      Because the Speech Synthesis API does not provide MP3s, you should store your notes, not the audio
+      itself. Save the cleaned text and your listening notes in a secure document. If you need an audio
+      record, use your operating system’s screen recorder with system audio while ensuring you have
+      rights to the material.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Sharing devices and classrooms</h2>
+    <p>
+      In classrooms or libraries, log out of personal accounts and avoid pasting private text. If
+      Read‑Aloud is part of an accommodation, coordinate with your instructor so they know audio is for
+      accessibility, not distraction. Use the <a href="../help.html">Help Center</a> if voices are locked down on managed devices.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Data retention</h2>
+    <p>
+      Read‑Aloud stores no pasted text. Your browser may keep the page in memory until you close it. For
+      extra assurance, refresh the tab or close the browser after a session. Ads run only on content pages like this guide; the <a href="../app.html">tool</a> intentionally avoids loading ad scripts next to user text.
+    </p>
+  </section>
+
+  <section class="related">
+    <h3>Related guides</h3>
+    <ul>
+      <li><a href="tts-for-students.html">Student Workflow</a></li>
+      <li><a href="tts-for-writers.html">TTS for Writers</a></li>
+      <li><a href="tts-voice-selection.html">Voice Selection</a></li>
+      <li><a href="tts-for-adhd-focus.html">TTS for Focus</a></li>
+    </ul>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html" aria-current="page">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html">Voices</a>
+    <a href="../about.html">About</a>
+    <a href="../contact.html">Contact</a>
+    <a href="../privacy.html">Privacy</a>
+    <a href="../terms.html">Terms</a>
+    <a href="../privacy.html#controls">Privacy settings</a>
+    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="../sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Privacy-first by design.</div>
+</footer>
+</body>
+</html>

--- a/guides/tts-study-loop-templates.html
+++ b/guides/tts-study-loop-templates.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Copy/Paste Templates: Study Loops, Active Recall Prompts, and Listening Checklists</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Ready-made study loops for Read‑Aloud: timers, prompts, and checklists you can paste beside the player for focused sessions." />
+  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-study-loop-templates.html">
+  <link rel="stylesheet" href="../site.css">
+</head>
+<body>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="../index.html">Home</a>
+      <a href="../app.html">Tool</a>
+      <a href="../guides.html" aria-current="page">Guides</a>
+      <a href="../help.html">Help</a>
+      <a href="../voices.html">Voices</a>
+      <a href="../about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Study Loops</div>
+  <h1>Copy/Paste Templates: Study Loops, Active Recall Prompts, and Listening Checklists</h1>
+  <p class="guide-meta">Use these micro-routines with the Read‑Aloud tool. Copy a template into your notes, set a timer, and let the player handle pacing.</p>
+
+  <section class="card guide-section">
+    <h2>How to use the templates</h2>
+    <p>
+      Keep Read‑Aloud open on the left and your notes app on the right. Copy the template that fits your
+      task, start the timer, and listen. When the timer ends, stop the audio, answer the prompts, and
+      paste your next section of text. The repetition keeps sessions predictable and easy to resume.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>15-minute comprehension loop</h2>
+    <pre class="callout">Timer: 15 minutes
+Paste: 400–600 words
+Listen at: 1.0×
+Prompts:
+1) Write three facts in your own words.
+2) Why does this matter? (2 sentences)
+3) One thing to review later: ________
+Action: Pause at 50% if lost; resume after a 30-second stretch.</pre>
+    <p>Use this when you need a quick refresh before class or a meeting.</p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Proofreading sprint</h2>
+    <pre class="callout">Timer: 20 minutes
+Paste: 500–900 words
+Listen at: 0.95–1.1×
+Prompts:
+- Circle fillers (“just,” “very,” “basically”).
+- Highlight sentences that sound flat.
+- Mark spots that need an example.
+Action: Switch to a contrasting voice halfway through.</pre>
+    <p>Pair this with the <a href="tts-for-writers.html">writer’s guide</a> for more editing tactics.</p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Language shadowing loop</h2>
+    <pre class="callout">Timer: 10 minutes
+Paste: 150–250 words
+Listen at: 0.9× then 1.0×
+Prompts:
+- New words to mimic: ________
+- Phrases to reuse: ________
+- Tone/intonation notes: ________
+Action: Record a 20-second clip at the end and compare.</pre>
+    <p>Switch voices if the default accent does not match your target dialect.</p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Deep dive with active recall</h2>
+    <pre class="callout">Timer: 25 minutes
+Paste: 700–1,000 words
+Listen at: 1.0×
+Prompts:
+1) What is the central claim?
+2) Which three terms need definitions?
+3) Where would you challenge the author?
+Action: Pause at 30% and 70% to answer prompts before continuing.</pre>
+    <p>This loop is ideal for long-form articles or research summaries.</p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Checklist for every loop</h2>
+    <ul>
+      <li>Test audio once before starting a big block.</li>
+      <li>Keep a backup voice selected in case the default glitches.</li>
+      <li>Log your speed and voice choice so you can repeat what worked.</li>
+      <li>Stay in the foreground tab to avoid browser throttling mid-loop.</li>
+    </ul>
+  </section>
+
+  <section class="related">
+    <h3>Related guides</h3>
+    <ul>
+      <li><a href="tts-for-students.html">Student Workflow</a></li>
+      <li><a href="tts-for-adhd-focus.html">TTS for Focus</a></li>
+      <li><a href="tts-for-language-shadowing.html">Shadowing Practice</a></li>
+      <li><a href="tts-voice-selection.html">Voice Selection</a></li>
+    </ul>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html" aria-current="page">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html">Voices</a>
+    <a href="../about.html">About</a>
+    <a href="../contact.html">Contact</a>
+    <a href="../privacy.html">Privacy</a>
+    <a href="../terms.html">Terms</a>
+    <a href="../privacy.html#controls">Privacy settings</a>
+    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="../sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Study loops you can run in minutes.</div>
+</footer>
+</body>
+</html>

--- a/guides/tts-study-loop-templates.html
+++ b/guides/tts-study-loop-templates.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Copy/Paste Templates: Study Loops, Active Recall Prompts, and Listening Checklists</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Ready-made study loops for Read‑Aloud: timers, prompts, and checklists you can paste beside the player for focused sessions." />
-  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-study-loop-templates.html">
-  <link rel="stylesheet" href="../site.css">
+  <link rel="canonical" href="https://read-aloud.com/guides/tts-study-loop-templates.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="../index.html">Home</a>
-      <a href="../app.html">Tool</a>
-      <a href="../guides.html" aria-current="page">Guides</a>
-      <a href="../help.html">Help</a>
-      <a href="../voices.html">Voices</a>
-      <a href="../about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Study Loops</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> <a href="/guides.html">Guides</a> <span aria-hidden="true">›</span> Study Loops</div>
   <h1>Copy/Paste Templates: Study Loops, Active Recall Prompts, and Listening Checklists</h1>
   <p class="guide-meta">Use these micro-routines with the Read‑Aloud tool. Copy a template into your notes, set a timer, and let the player handle pacing.</p>
 
@@ -115,18 +114,18 @@ Action: Pause at 30% and 70% to answer prompts before continuing.</pre>
 
 <footer>
   <div>
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html" aria-current="page">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../about.html">About</a>
-    <a href="../contact.html">Contact</a>
-    <a href="../privacy.html">Privacy</a>
-    <a href="../terms.html">Terms</a>
-    <a href="../privacy.html#controls">Privacy settings</a>
-    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="../sitemap.xml">Sitemap</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html" aria-current="page">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/privacy.html#controls">Privacy settings</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Study loops you can run in minutes.</div>
 </footer>

--- a/guides/tts-voice-selection.html
+++ b/guides/tts-voice-selection.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>How to Choose the Best Voice: Comfort, Fatigue, and Comprehension</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Pick the right system voice for Read‑Aloud. Compare tone, speed, fatigue, and accessibility tradeoffs with a simple testing script." />
+  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-voice-selection.html">
+  <link rel="stylesheet" href="../site.css">
+</head>
+<body>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="../index.html">Home</a>
+      <a href="../app.html">Tool</a>
+      <a href="../guides.html" aria-current="page">Guides</a>
+      <a href="../help.html">Help</a>
+      <a href="../voices.html">Voices</a>
+      <a href="../about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Voice Selection</div>
+  <h1>How to Choose the Best Voice: Comfort, Fatigue, and Comprehension</h1>
+  <p class="guide-meta">A five-step process for picking voices that match your task—studying, editing, or shadowing—without tiring your ears.</p>
+
+  <section class="card guide-section">
+    <h2>Start with a short testing script</h2>
+    <p>
+      Use the same 120–150 word paragraph to compare voices. Pick text that reflects your real use
+      case: a news brief for studying, a draft paragraph for writing, or a conversation for language
+      practice. Paste it into the <a href="../app.html">tool</a> and keep it handy for future comparisons.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Evaluate comfort first</h2>
+    <p>
+      Listen to the script at 1.0× with each available voice. After 60 seconds, rate:
+    </p>
+    <ul>
+      <li><strong>Tone:</strong> Does the voice sound harsh or soothing? Avoid brittle high-end voices if you are sensitive to treble.</li>
+      <li><strong>Clarity:</strong> Are consonants crisp? Muddier voices can obscure technical terms.</li>
+      <li><strong>Fatigue:</strong> Do you feel tense? If shoulders or jaw tighten, switch voices.</li>
+    </ul>
+    <p>
+      Remove any voice that fails comfort before considering speed or accent. Comfort keeps you listening longer.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Match voice to task</h2>
+    <ul>
+      <li><strong>Studying:</strong> Choose a steady, mid-range voice. Keep speed around 1.0× for comprehension. Pair with the <a href="../guides/tts-for-students.html">student workflow</a>.</li>
+      <li><strong>Proofreading:</strong> Pick a voice that contrasts with your own. Slightly faster speeds (1.05–1.15×) surface filler words.</li>
+      <li><strong>Accessibility/relaxation:</strong> Use a soft voice at 0.9–1.0× to reduce cognitive load.</li>
+      <li><strong>Language practice:</strong> Select regional accents that match your target dialect. Slow to 0.9× for tone languages.</li>
+    </ul>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Adjust for device and environment</h2>
+    <p>
+      Speakers can change how a voice feels. On laptops, brighter voices cut through fan noise. On
+      phones, warmer voices reduce hiss from small speakers. If you use Bluetooth earbuds, test for
+      connection stability by pausing and resuming; if audio lags, switch to wired headphones for long sessions.
+    </p>
+    <p>
+      Some browsers render voices slightly differently. If a voice stutters in one browser, try another
+      before giving up on it.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Create a personal preset list</h2>
+    <p>Document two or three go-to voices for different contexts:</p>
+    <ul>
+      <li><strong>Focus voice:</strong> Calm, medium speed, used for most reading.</li>
+      <li><strong>Edit voice:</strong> Contrasting tone, slightly faster.</li>
+      <li><strong>Practice voice:</strong> Accent-specific for language drills.</li>
+    </ul>
+    <p>
+      Note the voice name and preferred speed in a note or sticky. When you open Read‑Aloud, select the
+      preset quickly instead of re-evaluating each time.
+    </p>
+  </section>
+
+  <section class="card guide-section">
+    <h2>Revisit after updates</h2>
+    <p>
+      Operating system updates sometimes add voices or change audio quality. After a major update, run
+      your testing script again. If a favorite voice disappears, check the <a href="../voices.html">Voice Gallery</a> for reinstall steps and the <a href="../help.html">Help Center</a> for missing-voice fixes.
+    </p>
+  </section>
+
+  <section class="related">
+    <h3>Related guides</h3>
+    <ul>
+      <li><a href="tts-for-writers.html">TTS for Writers</a></li>
+      <li><a href="tts-for-students.html">Student Workflow</a></li>
+      <li><a href="tts-for-language-shadowing.html">Shadowing Practice</a></li>
+      <li><a href="tts-privacy-safety.html">Privacy &amp; Safety</a></li>
+    </ul>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html" aria-current="page">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html">Voices</a>
+    <a href="../about.html">About</a>
+    <a href="../contact.html">Contact</a>
+    <a href="../privacy.html">Privacy</a>
+    <a href="../terms.html">Terms</a>
+    <a href="../privacy.html#controls">Privacy settings</a>
+    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="../sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Voices tuned for comfort and comprehension.</div>
+</footer>
+</body>
+</html>

--- a/guides/tts-voice-selection.html
+++ b/guides/tts-voice-selection.html
@@ -3,31 +3,30 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>How to Choose the Best Voice: Comfort, Fatigue, and Comprehension</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Pick the right system voice for Read‑Aloud. Compare tone, speed, fatigue, and accessibility tradeoffs with a simple testing script." />
-  <link rel="canonical" href="https://www.read-aloud.com/guides/tts-voice-selection.html">
-  <link rel="stylesheet" href="../site.css">
+  <link rel="canonical" href="https://read-aloud.com/guides/tts-voice-selection.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="../index.html">Home</a>
-      <a href="../app.html">Tool</a>
-      <a href="../guides.html" aria-current="page">Guides</a>
-      <a href="../help.html">Help</a>
-      <a href="../voices.html">Voices</a>
-      <a href="../about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="../index.html">Home</a> <span aria-hidden="true">›</span> <a href="../guides.html">Guides</a> <span aria-hidden="true">›</span> Voice Selection</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> <a href="/guides.html">Guides</a> <span aria-hidden="true">›</span> Voice Selection</div>
   <h1>How to Choose the Best Voice: Comfort, Fatigue, and Comprehension</h1>
   <p class="guide-meta">A five-step process for picking voices that match your task—studying, editing, or shadowing—without tiring your ears.</p>
 
@@ -36,7 +35,7 @@
     <p>
       Use the same 120–150 word paragraph to compare voices. Pick text that reflects your real use
       case: a news brief for studying, a draft paragraph for writing, or a conversation for language
-      practice. Paste it into the <a href="../app.html">tool</a> and keep it handy for future comparisons.
+      practice. Paste it into the <a href="/app.html">tool</a> and keep it handy for future comparisons.
     </p>
   </section>
 
@@ -58,7 +57,7 @@
   <section class="card guide-section">
     <h2>Match voice to task</h2>
     <ul>
-      <li><strong>Studying:</strong> Choose a steady, mid-range voice. Keep speed around 1.0× for comprehension. Pair with the <a href="../guides/tts-for-students.html">student workflow</a>.</li>
+      <li><strong>Studying:</strong> Choose a steady, mid-range voice. Keep speed around 1.0× for comprehension. Pair with the <a href="/guides/tts-for-students.html">student workflow</a>.</li>
       <li><strong>Proofreading:</strong> Pick a voice that contrasts with your own. Slightly faster speeds (1.05–1.15×) surface filler words.</li>
       <li><strong>Accessibility/relaxation:</strong> Use a soft voice at 0.9–1.0× to reduce cognitive load.</li>
       <li><strong>Language practice:</strong> Select regional accents that match your target dialect. Slow to 0.9× for tone languages.</li>
@@ -96,7 +95,7 @@
     <h2>Revisit after updates</h2>
     <p>
       Operating system updates sometimes add voices or change audio quality. After a major update, run
-      your testing script again. If a favorite voice disappears, check the <a href="../voices.html">Voice Gallery</a> for reinstall steps and the <a href="../help.html">Help Center</a> for missing-voice fixes.
+      your testing script again. If a favorite voice disappears, check the <a href="/voices.html">Voice Gallery</a> for reinstall steps and the <a href="/help.html">Help Center</a> for missing-voice fixes.
     </p>
   </section>
 
@@ -113,18 +112,18 @@
 
 <footer>
   <div>
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html" aria-current="page">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../about.html">About</a>
-    <a href="../contact.html">Contact</a>
-    <a href="../privacy.html">Privacy</a>
-    <a href="../terms.html">Terms</a>
-    <a href="../privacy.html#controls">Privacy settings</a>
-    <a href="../recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="../sitemap.xml">Sitemap</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html" aria-current="page">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/privacy.html#controls">Privacy settings</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Voices tuned for comfort and comprehension.</div>
 </footer>

--- a/help.html
+++ b/help.html
@@ -9,31 +9,30 @@
     gtag('js', new Date());
     gtag('config', 'G-SVGML1VGPG');
   </script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Help Center | Read‑Aloud Troubleshooting</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Read‑Aloud Help Center: checklists for no sound on iPhone/iPad, empty voice lists, offline behavior, long text performance, limitations, and FAQs." />
-  <link rel="canonical" href="https://www.read-aloud.com/help.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/help.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html" aria-current="page">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html" aria-current="page">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Help</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Help</div>
   <h1>Help Center</h1>
   <p class="lead">Troubleshooting steps, platform-specific checklists, and answers to the questions we hear most often about Read‑Aloud.</p>
 
@@ -64,7 +63,7 @@
         <li>Try another browser such as Chrome for iOS. It still uses Safari’s engine but sometimes refreshes the voice list when Safari stalls.</li>
       </ol>
       <p>
-        If the issue persists, reboot the device to clear the speech queue, then open <a href="app.html">read-aloud.com/app</a> as the first tab and retest.
+        If the issue persists, reboot the device to clear the speech queue, then open <a href="/app.html">read-aloud.com/app</a> as the first tab and retest.
       </p>
     </div>
   </section>
@@ -83,7 +82,7 @@
         <li>If you are on a managed school device, confirm that speech synthesis is allowed. Some admin profiles disable it.</li>
       </ul>
       <p>
-        The <a href="voices.html">Voice Gallery</a> explains how each platform exposes voices and how to add more. After installing a new voice, close and reopen the browser to refresh the list.
+        The <a href="/voices.html">Voice Gallery</a> explains how each platform exposes voices and how to add more. After installing a new voice, close and reopen the browser to refresh the list.
       </p>
     </div>
   </section>
@@ -99,7 +98,7 @@
         streaming for privacy reasons.
       </p>
       <p>
-        Before boarding a flight or heading into a low-signal area, open <a href="app.html">the tool</a>,
+        Before boarding a flight or heading into a low-signal area, open <a href="/app.html">the tool</a>,
         choose a voice, and press Start for a few seconds. That initial playback caches the voice. If
         you later see errors offline, shorten the pasted text and make sure your device is not killing
         the browser tab in battery-saver mode.
@@ -122,8 +121,8 @@
         <li>For research, keep a notepad next to the player and jot timestamps when you hear something to revisit.</li>
       </ul>
       <p>
-        The <a href="guides/tts-for-adhd-focus.html">Focus guide</a> and
-        <a href="guides/tts-voice-selection.html">Voice Selection guide</a> include pacing templates
+        The <a href="/guides/tts-for-adhd-focus.html">Focus guide</a> and
+        <a href="/guides/tts-voice-selection.html">Voice Selection guide</a> include pacing templates
         that balance comprehension with speed.
       </p>
     </div>
@@ -142,7 +141,7 @@
         <li><strong>Voice quality varies:</strong> The app lists what your device provides; premium voices require installing them at the OS level.</li>
       </ul>
       <p>
-        We track browser changes and update the <a href="about.html">About page</a> with roadmap items when APIs evolve.
+        We track browser changes and update the <a href="/about.html">About page</a> with roadmap items when APIs evolve.
       </p>
     </div>
   </section>
@@ -157,25 +156,25 @@
       <h3>Is my text stored?</h3>
       <p>No. Everything runs locally in your browser. Analytics track page visits only, not the text itself.</p>
       <h3>Where can I get live help?</h3>
-      <p>Send a message through the <a href="contact.html">Contact page</a>. Include your browser, device, and a short description of what happened so we can reproduce the issue.</p>
+      <p>Send a message through the <a href="/contact.html">Contact page</a>. Include your browser, device, and a short description of what happened so we can reproduce the issue.</p>
     </div>
   </section>
 </main>
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html" aria-current="page">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html" aria-current="page">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Troubleshooting content last updated for current browser releases.</div>
 </footer>

--- a/help.html
+++ b/help.html
@@ -1,96 +1,183 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-<meta charset="utf-8">
-<title>Help & FAQ | Read-Aloud</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="description" content="Troubleshooting and frequently-asked questions for the free Read-Aloud text-to-speech tool.">
-<style>
-body{margin:0;font:16px/1.6 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0;font-size:1.9em}
-h2{margin-top:1.6em}
-dl dt{font-weight:700;margin-top:12px}
-.ads{text-align:center;margin:32px 0}
-</style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SVGML1VGPG');
+  </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Help Center | Read‑Aloud Troubleshooting</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Read‑Aloud Help Center: checklists for no sound on iPhone/iPad, empty voice lists, offline behavior, long text performance, limitations, and FAQs." />
+  <link rel="canonical" href="https://www.read-aloud.com/help.html">
+  <link rel="stylesheet" href="site.css">
 </head>
-
 <body>
 <header>
-  <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html" aria-current="page">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html" aria-current="page">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
 </header>
 
 <main>
-  <h1>Help &amp; Frequently Asked Questions</h1>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Help</div>
+  <h1>Help Center</h1>
+  <p class="lead">Troubleshooting steps, platform-specific checklists, and answers to the questions we hear most often about Read‑Aloud.</p>
 
-  <h2>Quick Troubleshooting</h2>
-  <dl>
-    <dt>I clicked “Start” but hear nothing on iPhone.</dt>
-    <dd>
-      • Make sure the <strong>Ring/Silent switch</strong> (left side of device) is <em>not</em> orange.<br>
-      • Disable <strong>Lockdown Mode</strong> (Settings ▶ Privacy & Security).<br>
-      • Refresh the page and press <kbd>Start</kbd> again.
-    </dd>
+  <section class="table-of-contents card">
+    <h2 style="margin-top:0">Quick navigation</h2>
+    <ul>
+      <li><a href="#iphone-ipad">No sound on iPhone or iPad</a></li>
+      <li><a href="#empty-voices">Empty or missing voice list</a></li>
+      <li><a href="#offline">Using Read‑Aloud offline</a></li>
+      <li><a href="#long-text">Performance tips for long text</a></li>
+      <li><a href="#limitations">Known limitations</a></li>
+      <li><a href="#faq">Frequently asked questions</a></li>
+    </ul>
+  </section>
 
-    <dt>Safari says the voice list is empty.</dt>
-    <dd>Our code sends a silent “kick” utterance, but some older iOS builds need a second tap on <kbd>Start</kbd>. If you still see no voices, switch to Chrome or update iOS.</dd>
+  <section id="iphone-ipad">
+    <h2>iPhone and iPad: fixing no-sound playback</h2>
+    <div class="card">
+      <p>
+        iOS and iPadOS protect speakers until you explicitly allow a page to play sound. If Read‑Aloud
+        looks like it is playing but you do not hear audio, work through this checklist in order.
+      </p>
+      <ol>
+        <li>Flip the physical mute switch to the unmuted position. Some models still route Safari audio through the ringer mute toggle.</li>
+        <li>Press the hardware volume up button twice while Safari is open to raise the media volume, not the ringer volume.</li>
+        <li>Tap inside the page once and press the <strong>Start</strong> button again. Mobile Safari requires a user gesture before allowing speech synthesis.</li>
+        <li>If you are using Guided Access or Focus modes, briefly exit them and retry; some profiles block web audio.</li>
+        <li>Try another browser such as Chrome for iOS. It still uses Safari’s engine but sometimes refreshes the voice list when Safari stalls.</li>
+      </ol>
+      <p>
+        If the issue persists, reboot the device to clear the speech queue, then open <a href="app.html">read-aloud.com/app</a> as the first tab and retest.
+      </p>
+    </div>
+  </section>
 
-    <dt>Can I use the tool offline?</dt>
-    <dd>Yes—once the page loads, system voices work without a connection. If your browser has no voices, the fallback robotic voice (meSpeak) requires the initial download but then works offline.</dd>
+  <section id="empty-voices">
+    <h2>Empty or missing voice list</h2>
+    <div class="card">
+      <p>
+        Read‑Aloud depends on voices provided by your operating system. When the dropdown appears
+        empty, it usually means the browser could not load the list yet. Try these steps:
+      </p>
+      <ul>
+        <li>Reload the page after waiting five seconds. Some browsers populate the list only after the <code>voiceschanged</code> event fires.</li>
+        <li>Switch browsers. Chrome, Edge, and Safari expose more voices than some privacy or kiosk browsers.</li>
+        <li>Install additional system voices. On macOS, open <em>System Settings → Accessibility → Spoken Content</em>; on Windows, open <em>Settings → Time &amp; Language → Speech</em>; on Android, open <em>Settings → Text-to-speech output</em>.</li>
+        <li>If you are on a managed school device, confirm that speech synthesis is allowed. Some admin profiles disable it.</li>
+      </ul>
+      <p>
+        The <a href="voices.html">Voice Gallery</a> explains how each platform exposes voices and how to add more. After installing a new voice, close and reopen the browser to refresh the list.
+      </p>
+    </div>
+  </section>
 
-    <dt>Does any text I paste leave my device?</dt>
-    <dd>No. Speech is generated by the browser’s own engine; we never send your text to our server.</dd>
+  <section id="offline">
+    <h2>Using Read‑Aloud offline</h2>
+    <div class="card">
+      <p>
+        Read‑Aloud can keep speaking while offline as long as the page is already loaded and the
+        selected voice is stored locally. System voices on macOS, iOS, Windows, and ChromeOS usually
+        work without connectivity after the first use. Cloud-only voices offered by some extensions or
+        third-party engines will not show up here because the tool intentionally avoids external
+        streaming for privacy reasons.
+      </p>
+      <p>
+        Before boarding a flight or heading into a low-signal area, open <a href="app.html">the tool</a>,
+        choose a voice, and press Start for a few seconds. That initial playback caches the voice. If
+        you later see errors offline, shorten the pasted text and make sure your device is not killing
+        the browser tab in battery-saver mode.
+      </p>
+    </div>
+  </section>
 
-    <dt>Can I download the spoken audio?</dt>
-    <dd>Not yet. The current release is browser-only playback. We’re exploring a safe way to export MP3 in the future without exposing user text to third-party servers.</dd>
-  </dl>
+  <section id="long-text">
+    <h2>Performance tips for long text</h2>
+    <div class="card">
+      <p>
+        Very long pastes can overwhelm the browser queue. Break documents into smaller sections—three
+        to five minutes of listening time is a sweet spot—and press Resume between sections to keep
+        your place. Lowering the speed to 0.9× can also improve stability on older devices.
+      </p>
+      <ul>
+        <li>Use headings as cut points. Copy one chapter or subheading at a time.</li>
+        <li>Close other tabs running audio or heavy scripts to free memory.</li>
+        <li>If timing is important, note the progress percentage when you pause so you can resume from a nearby paragraph.</li>
+        <li>For research, keep a notepad next to the player and jot timestamps when you hear something to revisit.</li>
+      </ul>
+      <p>
+        The <a href="guides/tts-for-adhd-focus.html">Focus guide</a> and
+        <a href="guides/tts-voice-selection.html">Voice Selection guide</a> include pacing templates
+        that balance comprehension with speed.
+      </p>
+    </div>
+  </section>
 
-  <h2>Keyboard Shortcuts</h2>
-  <ul>
-    <li><kbd>Ctrl + Enter</kbd> (or <kbd>⌘ + Enter</kbd> on Mac) – Start / Restart</li>
-    <li><kbd>Space</kbd> – Pause or Resume</li>
-    <li><kbd>Esc</kbd> – Stop and reset progress</li>
-  </ul>
+  <section id="limitations">
+    <h2>Known limitations</h2>
+    <div class="card">
+      <p>
+        Read‑Aloud runs entirely in your browser, so a few constraints are built-in:
+      </p>
+      <ul>
+        <li><strong>No MP3 export:</strong> The Speech Synthesis API does not return audio files. If you need recordings, consider native screen recording with system audio while respecting copyright.</li>
+        <li><strong>Sleep and lock screens:</strong> Laptops that go to sleep will pause playback. On mobile, keep the screen awake during long listens.</li>
+        <li><strong>Tab focus:</strong> Some browsers throttle background tabs. Keep Read‑Aloud in the foreground for the most reliable timing.</li>
+        <li><strong>Voice quality varies:</strong> The app lists what your device provides; premium voices require installing them at the OS level.</li>
+      </ul>
+      <p>
+        We track browser changes and update the <a href="about.html">About page</a> with roadmap items when APIs evolve.
+      </p>
+    </div>
+  </section>
 
-  <div class="ads">
-    <!-- responsive ad -->
-    <ins class="adsbygoogle"
-         style="display:block"
-         data-ad-client="ca-pub-4003447295960802"
-         data-ad-slot="YOUR_SLOT_ID"
-         data-ad-format="auto"
-         data-full-width-responsive="true"></ins>
-    <script async
-      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-    <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
-  </div>
+  <section id="faq">
+    <h2>Frequently asked questions</h2>
+    <div class="card">
+      <h3>Can I use Read‑Aloud for school?</h3>
+      <p>Yes. The tool is designed to be classroom-friendly and does not require sign-ins. Still, avoid pasting private student data.</p>
+      <h3>Does it work with PDFs?</h3>
+      <p>Copy the text from the PDF and paste it into the tool. Scanned PDFs without selectable text need OCR before they can be spoken.</p>
+      <h3>Is my text stored?</h3>
+      <p>No. Everything runs locally in your browser. Analytics track page visits only, not the text itself.</p>
+      <h3>Where can I get live help?</h3>
+      <p>Send a message through the <a href="contact.html">Contact page</a>. Include your browser, device, and a short description of what happened so we can reproduce the issue.</p>
+    </div>
+  </section>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html">Tool</a>
+    <a href="guides.html">Guides</a>
+    <a href="help.html" aria-current="page">Help</a>
+    <a href="voices.html">Voices</a>
+    <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Troubleshooting content last updated for current browser releases.</div>
 </footer>
 </body>
 </html>

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -1,56 +1,96 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>How It Works | Read-Aloud</title>
-  <meta name="description" content="Learn how our text-to-speech reader works in just a few simple steps.">
-  <link rel="stylesheet" href="styles.css">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>How Read‑Aloud Works</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Understand how Read‑Aloud uses the browser Speech Synthesis API, local voices, and progress tracking to read text aloud." />
+  <link rel="canonical" href="https://www.read-aloud.com/how-it-works.html">
+  <link rel="stylesheet" href="site.css">
 </head>
 <body>
-  <!-- HEADER -->
-  <header>
-  <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+<header>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
 </header>
 
-  <!-- MAIN CONTENT: How It Works -->
-  <main>
-    <section id="how-it-works">
-      <div class="container">
-        <h2>How It Works</h2>
-        <p>
-          Simply paste your text into the area on our homepage, select your language and voice, adjust the reading speed, and click “Start.” Enjoy real-time word highlighting and progress tracking as your text is read aloud.
-        </p>
-        <p>
-          For more in-depth guidance, check out our <a href="faq.html">FAQ</a> or <a href="contact.html">contact us</a> if you have specific questions.
-        </p>
-      </div>
-    </section>
-  </main>
+<main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> How It Works</div>
+  <h1>How Read‑Aloud Works</h1>
+  <p class="lead">A quick explanation of what happens after you press Start. No plugins, no uploads—just the voices already on your device.</p>
 
-  <!-- FOOTER -->
-  <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <section class="card">
+    <h2>1) Text stays local</h2>
+    <p>
+      When you paste text into <a href="app.html">the tool</a>, it never leaves your browser. Read‑Aloud
+      calls the Speech Synthesis API built into Chrome, Edge, Safari, and other modern browsers. That API
+      turns your text into audio using voices your operating system already includes.
+    </p>
+  </section>
+
+  <section class="card">
+    <h2>2) Voices are discovered on your device</h2>
+    <p>
+      The tool requests the list of voices from the browser, filters them by the language dropdown you
+      choose, and populates the menu. If you add more voices in system settings, a quick refresh pulls
+      them into the list. See the <a href="voices.html">Voice Gallery</a> for install steps.
+    </p>
+  </section>
+
+  <section class="card">
+    <h2>3) Playback is chunked for stability</h2>
+    <p>
+      Long passages are split into manageable chunks before speaking. As each chunk finishes, the progress
+      bar and percentage update. If you change speed mid-way, the next chunk uses the new rate. This keeps
+      playback responsive without overwhelming the browser.
+    </p>
+  </section>
+
+  <section class="card">
+    <h2>4) Controls stay keyboard-friendly</h2>
+    <p>
+      Keyboard shortcuts work after the first tap that grants audio permission: Start (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd>), Pause, Resume, Stop, and a quick focus shortcut (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Y</kbd>) to jump back into the text box.
+    </p>
+  </section>
+
+  <section class="card">
+    <h2>5) Limits to keep in mind</h2>
+    <p>
+      The browser may pause audio when a device sleeps, and MP3 export is not available because the API
+      does not return audio files. For offline use, load the page and start playback once while online to
+      cache the voice. More details live in the <a href="help.html">Help Center</a>.
+    </p>
+  </section>
+</main>
+
+<footer>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html">Tool</a>
+    <a href="guides.html">Guides</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
+    <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Built on the Speech Synthesis API.</div>
 </footer>
 </body>
 </html>

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -3,38 +3,37 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>How Read‑Aloud Works</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Understand how Read‑Aloud uses the browser Speech Synthesis API, local voices, and progress tracking to read text aloud." />
-  <link rel="canonical" href="https://www.read-aloud.com/how-it-works.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/how-it-works.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> How It Works</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> How It Works</div>
   <h1>How Read‑Aloud Works</h1>
   <p class="lead">A quick explanation of what happens after you press Start. No plugins, no uploads—just the voices already on your device.</p>
 
   <section class="card">
     <h2>1) Text stays local</h2>
     <p>
-      When you paste text into <a href="app.html">the tool</a>, it never leaves your browser. Read‑Aloud
+      When you paste text into <a href="/app.html">the tool</a>, it never leaves your browser. Read‑Aloud
       calls the Speech Synthesis API built into Chrome, Edge, Safari, and other modern browsers. That API
       turns your text into audio using voices your operating system already includes.
     </p>
@@ -45,7 +44,7 @@
     <p>
       The tool requests the list of voices from the browser, filters them by the language dropdown you
       choose, and populates the menu. If you add more voices in system settings, a quick refresh pulls
-      them into the list. See the <a href="voices.html">Voice Gallery</a> for install steps.
+      them into the list. See the <a href="/voices.html">Voice Gallery</a> for install steps.
     </p>
   </section>
 
@@ -70,25 +69,25 @@
     <p>
       The browser may pause audio when a device sleeps, and MP3 export is not available because the API
       does not return audio files. For offline use, load the page and start playback once while online to
-      cache the voice. More details live in the <a href="help.html">Help Center</a>.
+      cache the voice. More details live in the <a href="/help.html">Help Center</a>.
     </p>
   </section>
 </main>
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Built on the Speech Synthesis API.</div>
 </footer>

--- a/index.html
+++ b/index.html
@@ -1,293 +1,234 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=Edge">
-<meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
-<title>Read-Aloud | FREE Text-to-Speech</title>
-
-<!-- ——— Retro CSS ——— -->
-<style>
-body{margin:0;background:#000080 url("bg_tile.gif") repeat;color:#fffc;font:14px Verdana}
-
-/* banner push */
-#top{background:#000040;border-bottom:3px double #ff0;text-align:center;padding:6px}
-#top h1{margin:4px 0;font:48px "Comic Sans MS";color:#0f0;text-shadow:2px 2px #f0f}
-
-/* nav */
-#mainNav{background:#002060;border-bottom:3px double #ff0;text-align:center;padding:6px}
-#mainNav a{color:#fff;text-decoration:none;margin:0 10px;font:15px/1.4 Verdana}
-#mainNav a:hover,#mainNav a:focus{text-decoration:underline}
-
-/* subtle support bar */
-#supportBar{position:relative;background:#00124a;border-bottom:2px solid #334;
-            font:13px Verdana;padding:3px 8px;color:#e0e0ff;
-            display:flex;justify-content:center;align-items:center;gap:10px}
-#supportBar .fill{position:absolute;top:0;left:0;height:100%;background:#ff0;opacity:.20}
-#supportBar .msg{position:relative;z-index:2;white-space:nowrap}
-.coffeeBtn{position:relative;z-index:2;color:#ff0;text-decoration:none;
-           border-bottom:1px dotted #ff0;padding:0 2px}
-.coffeeBtn:hover,.coffeeBtn:focus{background:#ff0;color:#000;border:none}
-@media(max-width:480px){#supportBar{gap:6px;flex-wrap:wrap;font-size:12px}}
-
-/* tool panel */
-.panel{margin:14px;background:#001a66;border:2px outset #ff0;padding:12px}
-textarea{width:100%;min-height:120px;padding:4px;border:3px inset #666;
-         font:15px/1.4 "Courier New";box-sizing:border-box}
-.btn{background:#ff0;border:2px outset #333;font:14px Tahoma;padding:6px 14px;color:#000;cursor:pointer}
-.highlight{background:#f0f;color:#000}
-progress{width:100%;height:12px;border:2px inset #333;background:#333}
-progress::-webkit-progress-value{background:#0f0}
-@media(max-width:640px){body{font-size:13px}}
-
-/* footer */
-footer{background:#002060;color:#fff;padding:8px 0;text-align:center;font:14px Verdana}
-footer a{color:#fff;text-decoration:none;margin:0 6px}
-footer a:hover{text-decoration:underline}
-footer .small{display:block;font-size:12px;color:#e0e0ff;margin-top:4px}
-</style>
-
-<!-- Google AdSense -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SVGML1VGPG');
+  </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
+  <title>Read‑Aloud | Free Text-to-Speech for Everyday Reading</title>
+  <meta name="description" content="Read‑Aloud turns text into speech directly in your browser. Learn how students, writers, and accessibility-minded readers use the tool plus guides, help, and support." />
+  <link rel="canonical" href="https://www.read-aloud.com/">
+  <link rel="stylesheet" href="site.css">
 </head>
-
 <body>
-
-<!-- header -->
 <header>
-  <div id="top"><h1>Read-Aloud</h1></div>
-  <nav id="mainNav">
-    <a href="index.html" aria-current="page">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html" aria-current="page">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
 </header>
 
-<!-- support bar -->
-<div id="supportBar" role="region" aria-label="Support Read-Aloud">
-  <div class="fill" id="goalFill"></div>
-  <span id="goalMsg" class="msg"></span>
-  <a href="https://coff.ee/readaloud" target="_blank" rel="noopener"
-     class="coffeeBtn" aria-label="Buy me a coffee">☕ Buy me a coffee</a>
-</div>
+<main>
+  <section class="hero">
+    <p class="tag">Free in-browser text-to-speech</p>
+    <h1>Read‑Aloud turns any text into natural speech without sign ups or downloads.</h1>
+    <p>
+      Paste the text you own, choose a system voice you like, and let Read‑Aloud read back articles,
+      homework, reports, or drafts. The tool runs fully in your browser using built-in voices,
+      so nothing you paste leaves your device.
+    </p>
+    <p class="lead">
+      This page explains what the tool does, when to use it, how to avoid common issues,
+      and where to find deeper guides written for students, writers, and accessibility-minded readers.
+    </p>
+    <div style="margin-top:18px; display:flex; gap:12px; flex-wrap:wrap; align-items:center;">
+      <a class="button-primary" href="app.html">Open the Tool</a>
+      <span class="small">Looking for help? Visit the <a href="help.html" style="color:#fff;text-decoration:underline;">Help Center</a>.</span>
+    </div>
+  </section>
 
-<!-- main panel -->
-<div class="panel">
-  <textarea id="txt" placeholder="Paste or type text here…"></textarea><br><br>
+  <section>
+    <h2>What Read‑Aloud is and why it exists</h2>
+    <div class="grid two-col">
+      <div class="card">
+        <p>
+          Read‑Aloud started as a simple browser experiment: could a distraction-free web page make
+          the native speech synthesis API friendlier for everyday reading? Over time it grew into a
+          focused tool with progress meters, keyboard shortcuts, and clear privacy defaults so you
+          can keep your attention on the text instead of fiddling with menus.
+        </p>
+        <p>
+          Students use it to turn lecture notes into listenable study sessions. Writers and editors
+          rely on it to catch phrasing issues their eyes skipped over. Readers with low vision use it
+          to rest their eyes during long documents. Language learners pair slower playback with their
+          own reading to practice pronunciation and rhythm.
+        </p>
+      </div>
+      <div class="card">
+        <p>
+          The tool is deliberately lightweight. There is no account system, no cloud conversion, and
+          no upload to third parties. It leans on voices that already live inside your operating
+          system or browser. That design keeps latency low and makes the experience safe for school
+          laptops, locked-down tablets, and privacy-conscious professionals.
+        </p>
+        <p>
+          Everything you need stays on one page. If you want a quick walkthrough, the
+          <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> guide and the
+          <a href="guides.html">Guides library</a> break down the controls with screenshots and
+          practical routines.
+        </p>
+      </div>
+    </div>
+  </section>
 
-  <label>Language <select id="lang"></select></label>
-  <label style="margin-left:12px">Voice
-    <select id="voice"><option value="-1">Default</option></select>
-  </label><br><br>
+  <section>
+    <h2>How the tool works (and what it does not do)</h2>
+    <div class="card">
+      <p>
+        Read‑Aloud slices your text into manageable chunks, queues them for the Speech Synthesis
+        API, and updates the progress bar as each chunk finishes. Voice selection happens locally:
+        the tool asks your browser for available voices, filters them by language, and presents the
+        list in the dropdown. If you change the rate slider, the next chunk uses the new speed so you
+        can adjust pacing on the fly.
+      </p>
+      <p>
+        Because the tool uses system voices, playback quality depends on your operating system. On
+        macOS and iOS you will see premium-quality voices like “Siri Voice 4.” On Windows and some
+        Android builds you may see a smaller list. The <a href="voices.html">Voice Gallery</a>
+        explains why voice lists differ and how to add more options.
+      </p>
+      <p>
+        The browser sandbox means a few limits: MP3 export is not available because the Speech
+        Synthesis API does not provide audio blobs; background playback may pause when a laptop goes
+        to sleep; and some mobile browsers require a tap before they allow audio output. These limits
+        are described in more depth on the <a href="download-mp3.html">MP3 export note</a> and in
+        the <a href="help.html">Help Center</a> troubleshooting checklists.
+      </p>
+    </div>
+  </section>
 
-  <label>Speed <span id="rv">1</span>x
-    <input type="range" id="rate" min="0.5" max="2" step="0.1" value="1">
-  </label><br><br>
+  <section>
+    <h2>Who the tool is for</h2>
+    <div class="grid three-col">
+      <div class="card">
+        <h3>Students</h3>
+        <p>
+          Turn reading assignments into short listening sprints. Copy the section you need, set a
+          comfortable voice, and let the progress meter keep you honest about pacing. Pair the tool
+          with a timer and active-recall prompts from the
+          <a href="guides/tts-study-loop-templates.html">Study Loop Templates guide</a>.
+        </p>
+      </div>
+      <div class="card">
+        <h3>Writers &amp; editors</h3>
+        <p>
+          Listening exposes clunky phrasing that looks fine on screen. Keep the speed at 1.0× and tap
+          <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Y</kbd> to pause when you hear a sentence worth
+          rewriting. The <a href="guides/tts-for-writers.html">Proofreading guide for writers</a>
+          outlines a repeatable workflow.
+        </p>
+      </div>
+      <div class="card">
+        <h3>Accessibility &amp; focus</h3>
+        <p>
+          Readers managing eye strain, ADHD, or dyslexia often blend listening with on-screen
+          tracking. Use the slow-speed range (0.8–1.0×) and shorter chunks to keep place. The
+          <a href="guides/tts-for-adhd-focus.html">Focus guide</a> and
+          <a href="guides/tts-for-dyslexia-support.html">Dyslexia guide</a> include pacing ideas.
+        </p>
+      </div>
+    </div>
+  </section>
 
-  <button id="start"  class="btn">Start</button>
-  <button id="pause"  class="btn">Pause</button>
-  <button id="resume" class="btn">Resume</button>
-  <button id="stop"   class="btn">Stop</button><br><br>
+  <section>
+    <h2>Privacy posture and data handling</h2>
+    <div class="card">
+      <p>
+        Everything you paste stays in your browser tab. Read‑Aloud does not send text to a server,
+        store documents, or log what you type. Analytics capture only high-level usage to understand
+        which pages are visited, not what content you listen to. Ads are limited to informational
+        pages like this one; the <a href="app.html">Tool page</a> intentionally avoids ad loading so
+        user-pasted text is never next to ad code.
+      </p>
+      <p>
+        For extra caution, avoid pasting confidential contracts, protected student records, or
+        regulated medical details. When in doubt, use short excerpts or scrub sensitive fields. The
+        <a href="guides/tts-privacy-safety.html">Privacy &amp; Safety guide</a> lists safe habits
+        and explains why Read‑Aloud leans on local voices instead of cloud synthesis.
+      </p>
+    </div>
+  </section>
 
-  <progress id="bar" value="0" max="100"></progress>
-  <div id="meter"><strong>0 %</strong> — <span id="ela">00:00:00</span> | <span id="rem">00:00:00</span></div>
-  <div id="disp" aria-live="polite" style="margin-top:8px"></div>
-</div>
+  <section>
+    <h2>Troubleshooting at a glance</h2>
+    <div class="grid two-col">
+      <div class="card">
+        <h3>Common quick fixes</h3>
+        <ul>
+          <li>If you see an empty voice list, reload after unlocking your device audio or try another browser.</li>
+          <li>No sound on iPhone or iPad? Toggle the physical mute switch and confirm the tab has audio permission.</li>
+          <li>Text not finishing? Reduce the chunk size by shortening the pasted section and retry.</li>
+          <li>Hearing robotic output? Switch to a different system voice or lower the speed to 0.9×.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Where to get full answers</h3>
+        <p>
+          The <a href="help.html">Help Center</a> documents platform-specific fixes, including
+          offline behavior, missing voices, and performance tips. You can also jump straight to the
+          <a href="voices.html">Voice Gallery</a> for OS-specific install steps or send a detailed
+          report through the <a href="contact.html">Contact page</a> using the bug report template.
+        </p>
+        <p>
+          If you prefer structured walkthroughs, start with the <a href="guides.html">Guides</a>
+          collection. Each article ends with related links so you can dig deeper without searching
+          around the site.
+        </p>
+      </div>
+    </div>
+  </section>
 
-<!-- Helpful content section (improves site quality for visitors + AdSense review) -->
-<div class="panel">
-  <h2 style="margin-top:0;color:#ff0">What is Read‑Aloud?</h2>
-  <p>
-    <strong>Read‑Aloud</strong> is a free text‑to‑speech tool that reads your text out loud directly in your browser.
-    Paste anything you have the rights to use, pick a voice and speed, and press Start.
-  </p>
-  <p>
-    The tool is designed to be simple and distraction‑free. Many people use it for studying, proofreading,
-    accessibility support, and language practice.
-  </p>
+  <section>
+    <h2>How to make the most of Read‑Aloud</h2>
+    <div class="card">
+      <p>
+        Keep your sessions short and intentional. Break long papers into sections, use the Pause and
+        Resume buttons when you need to mark edits, and note tricky terms you want to double-check.
+        Consider pairing a comfortable pair of wired headphones with the Recommendations at the
+        bottom of this site for clearer audio and fewer distractions.
+      </p>
+      <p>
+        Looking for a place to start? Visit the <a href="guides/tts-for-students.html">student
+        workflow guide</a>, try the <a href="guides/tts-voice-selection.html">voice selection
+        playbook</a>, or copy the prompts from the
+        <a href="guides/tts-study-loop-templates.html">study loop templates</a>. When you are ready
+        to listen, head to the <a href="app.html">Tool</a> and press Start.
+      </p>
+    </div>
+  </section>
+</main>
 
-  <h3 style="color:#ff0;margin-bottom:6px">Popular Guides</h3>
-  <ul style="margin-top:6px">
-    <li><a href="guides.html" style="color:#ff0">Guides &amp; Tutorials (start here)</a></li>
-    <li><a href="guide-how-to-use.html" style="color:#ff0">How to Use Read‑Aloud (Step‑by‑Step)</a></li>
-    <li><a href="guide-study.html" style="color:#ff0">Study With Text‑to‑Speech</a></li>
-    <li><a href="guide-proofread.html" style="color:#ff0">Proofread by Ear</a></li>
-    <li><a href="guide-language-learning.html" style="color:#ff0">Language Learning With TTS</a></li>
-    <li><a href="guide-privacy.html" style="color:#ff0">Privacy‑First Text‑to‑Speech</a></li>
-    <li><a href="recommendations.html" style="color:#ff0">Recommended reading aids &amp; accessories</a></li>
-  </ul>
-
-  <p style="margin-top:12px;color:#e0e0ff">
-    Tip: If you run into issues on iPhone/iPad (no sound, no voices), see the <a href="help.html" style="color:#ff0">Help</a> page.
-  </p>
-</div>
-
-            
-
-
-<!-- Google 468×60 banner -->
-<div style="text-align:center;margin:14px">
-  <ins class="adsbygoogle" style="display:inline-block;width:468px;height:60px"
-       data-ad-client="ca-pub-4003447295960802" data-ad-slot="YOUR_GOOGLE_SLOT"></ins>
-  <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
-</div>
-            
-<!-- Amazon Affiliate Ad Widget (Responsive) -->
-<div style="margin:14px auto; max-width:320px; text-align:center;">
-  <p style="font:14px Verdana; color:#fff; margin:0 0 6px;">
-    We hand-pick assistive reading tools that pair well with Read-Aloud. Purchases made
-    through these recommendations support the site at no extra cost to you.
-  </p>
-  <div id="amazonWidget"></div>
-  <div id="curatedLinks" style="display:none; text-align:left; font:14px Verdana;"></div>
-  <script type="text/javascript">
-    const searchPhrases = [
-      "text to speech microphone",
-      "reading pen for dyslexia",
-      "dyslexia tools",
-      "assistive reading tablet",
-      "audio book headphones"
-    ];
-
-    // Rotate phrases weekly to keep the widget aligned with high-intent searches.
-    const rotationIndex = Math.floor(Date.now() / (1000 * 60 * 60 * 24 * 7)) % searchPhrases.length;
-    const selectedPhrase = searchPhrases[rotationIndex];
-
-    // Flip to curated links for experiments without changing the markup.
-    let useCuratedLinks = false;
-    const curatedProducts = [
-      {
-        title: "Text-to-Speech USB Microphone",
-        href: "https://www.amazon.com/s?k=text+to+speech+microphone&tag=nickdaly-20",
-        note: "Clear capture for narrating and dictation."
-      },
-      {
-        title: "Reading Pen for Dyslexia",
-        href: "https://www.amazon.com/s?k=reading+pen+dyslexia&tag=nickdaly-20",
-        note: "Scan-and-read support for faster comprehension."
-      },
-      {
-        title: "Assistive Listening Headphones",
-        href: "https://www.amazon.com/s?k=audio+book+headphones&tag=nickdaly-20",
-        note: "Comfortable for long listening sessions."
-      }
-    ];
-
-    const showCuratedLinks = () => {
-      if (useCuratedLinks) return;
-      useCuratedLinks = true;
-
-      const widget = document.getElementById('amazonWidget');
-      widget.innerHTML = '';
-
-      const curatedContainer = document.getElementById('curatedLinks');
-      curatedContainer.innerHTML = '';
-
-      const list = document.createElement('ul');
-      curatedProducts.forEach(item => {
-        const li = document.createElement('li');
-        li.style.marginBottom = '6px';
-        const link = document.createElement('a');
-        link.href = item.href;
-        link.target = '_blank';
-        link.rel = 'noopener';
-        link.textContent = item.title;
-        link.style.color = '#ff0';
-        li.appendChild(link);
-        if (item.note) {
-          const note = document.createElement('div');
-          note.textContent = item.note;
-          note.style.color = '#e0e0ff';
-          note.style.fontSize = '12px';
-          note.style.marginLeft = '4px';
-          li.appendChild(note);
-        }
-        list.appendChild(li);
-      });
-      curatedContainer.appendChild(list);
-      curatedContainer.style.display = 'block';
-    };
-
-    if (useCuratedLinks) {
-      showCuratedLinks();
-    } else {
-      const widget = document.getElementById('amazonWidget');
-      const configScript = document.createElement('script');
-      configScript.type = 'text/javascript';
-      configScript.text = `
-        amzn_assoc_placement = "adunit0";
-        amzn_assoc_tracking_id = "nickdaly-20";
-        amzn_assoc_ad_mode = "search";
-        amzn_assoc_ad_type = "smart";
-        amzn_assoc_marketplace = "amazon";
-        amzn_assoc_region = "US";
-        amzn_assoc_default_search_phrase = "${selectedPhrase}";
-        amzn_assoc_default_category = "All";
-      `;
-      widget.appendChild(configScript);
-
-      const loaderScript = document.createElement('script');
-      loaderScript.src = "//z-na.amazon-adsystem.com/widgets/onejs?MarketPlace=US";
-      loaderScript.onerror = showCuratedLinks;
-      widget.appendChild(loaderScript);
-
-      setTimeout(() => {
-        const hasIframe = widget.querySelector('iframe');
-        if (!hasIframe) {
-          showCuratedLinks();
-        }
-      }, 2500);
-    }
-  </script>
-</div>
-
-
-<!-- meSpeak fallback -->
-<script src="https://cdn.jsdelivr.net/npm/mespeak@2.0.2/mespeak.min.js"></script>
-<script>
-mespeak.loadConfig("https://cdn.jsdelivr.net/npm/mespeak@2.0.2/mespeak_config.json");
-mespeak.loadVoice("https://cdn.jsdelivr.net/npm/mespeak@2.0.2/voices/en/en.json");
-</script>
-
-<!-- main logic -->
-<script src="readaloud.js"></script>
-
-<!-- visit counter + goal fill -->
-<script>
-const RAISED = 19;  /* update whenever balance changes */
-const GOAL   = 60;
-
-fetch('https://api.countapi.xyz/hit/read-aloud-site/visits')
-  .then(r=>r.json()).then(d=>updateBar(d.value)).catch(()=>updateBar('many'));
-
-function updateBar(visits){
-  const pct = Math.min(100, RAISED/GOAL*100);
-  document.getElementById('goalFill').style.width = pct + '%';
-  document.getElementById('goalMsg').innerHTML =
-      `Free TTS for <strong>${visits.toLocaleString()}</strong> readers — `
-    + `<strong>$${RAISED} of $${GOAL}</strong> hosting funded`;
-}
-</script>
-
-<!-- footer -->
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html">Tool</a>
+    <a href="guides.html">Guides</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
+    <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,26 +9,25 @@
     gtag('js', new Date());
     gtag('config', 'G-SVGML1VGPG');
   </script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
   <title>Read‑Aloud | Free Text-to-Speech for Everyday Reading</title>
   <meta name="description" content="Read‑Aloud turns text into speech directly in your browser. Learn how students, writers, and accessibility-minded readers use the tool plus guides, help, and support." />
-  <link rel="canonical" href="https://www.read-aloud.com/">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html" aria-current="page">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html" aria-current="page">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
@@ -47,8 +46,8 @@
       and where to find deeper guides written for students, writers, and accessibility-minded readers.
     </p>
     <div style="margin-top:18px; display:flex; gap:12px; flex-wrap:wrap; align-items:center;">
-      <a class="button-primary" href="app.html">Open the Tool</a>
-      <span class="small">Looking for help? Visit the <a href="help.html" style="color:#fff;text-decoration:underline;">Help Center</a>.</span>
+      <a class="button-primary" href="/app.html">Open the Tool</a>
+      <span class="small">Looking for help? Visit the <a href="/help.html" style="color:#fff;text-decoration:underline;">Help Center</a>.</span>
     </div>
   </section>
 
@@ -79,7 +78,7 @@
         <p>
           Everything you need stays on one page. If you want a quick walkthrough, the
           <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> guide and the
-          <a href="guides.html">Guides library</a> break down the controls with screenshots and
+          <a href="/guides.html">Guides library</a> break down the controls with screenshots and
           practical routines.
         </p>
       </div>
@@ -99,7 +98,7 @@
       <p>
         Because the tool uses system voices, playback quality depends on your operating system. On
         macOS and iOS you will see premium-quality voices like “Siri Voice 4.” On Windows and some
-        Android builds you may see a smaller list. The <a href="voices.html">Voice Gallery</a>
+        Android builds you may see a smaller list. The <a href="/voices.html">Voice Gallery</a>
         explains why voice lists differ and how to add more options.
       </p>
       <p>
@@ -107,7 +106,7 @@
         Synthesis API does not provide audio blobs; background playback may pause when a laptop goes
         to sleep; and some mobile browsers require a tap before they allow audio output. These limits
         are described in more depth on the <a href="download-mp3.html">MP3 export note</a> and in
-        the <a href="help.html">Help Center</a> troubleshooting checklists.
+        the <a href="/help.html">Help Center</a> troubleshooting checklists.
       </p>
     </div>
   </section>
@@ -121,7 +120,7 @@
           Turn reading assignments into short listening sprints. Copy the section you need, set a
           comfortable voice, and let the progress meter keep you honest about pacing. Pair the tool
           with a timer and active-recall prompts from the
-          <a href="guides/tts-study-loop-templates.html">Study Loop Templates guide</a>.
+          <a href="/guides/tts-study-loop-templates.html">Study Loop Templates guide</a>.
         </p>
       </div>
       <div class="card">
@@ -129,7 +128,7 @@
         <p>
           Listening exposes clunky phrasing that looks fine on screen. Keep the speed at 1.0× and tap
           <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Y</kbd> to pause when you hear a sentence worth
-          rewriting. The <a href="guides/tts-for-writers.html">Proofreading guide for writers</a>
+          rewriting. The <a href="/guides/tts-for-writers.html">Proofreading guide for writers</a>
           outlines a repeatable workflow.
         </p>
       </div>
@@ -138,8 +137,8 @@
         <p>
           Readers managing eye strain, ADHD, or dyslexia often blend listening with on-screen
           tracking. Use the slow-speed range (0.8–1.0×) and shorter chunks to keep place. The
-          <a href="guides/tts-for-adhd-focus.html">Focus guide</a> and
-          <a href="guides/tts-for-dyslexia-support.html">Dyslexia guide</a> include pacing ideas.
+          <a href="/guides/tts-for-adhd-focus.html">Focus guide</a> and
+          <a href="/guides/tts-for-dyslexia-support.html">Dyslexia guide</a> include pacing ideas.
         </p>
       </div>
     </div>
@@ -152,13 +151,13 @@
         Everything you paste stays in your browser tab. Read‑Aloud does not send text to a server,
         store documents, or log what you type. Analytics capture only high-level usage to understand
         which pages are visited, not what content you listen to. Ads are limited to informational
-        pages like this one; the <a href="app.html">Tool page</a> intentionally avoids ad loading so
+        pages like this one; the <a href="/app.html">Tool page</a> intentionally avoids ad loading so
         user-pasted text is never next to ad code.
       </p>
       <p>
         For extra caution, avoid pasting confidential contracts, protected student records, or
         regulated medical details. When in doubt, use short excerpts or scrub sensitive fields. The
-        <a href="guides/tts-privacy-safety.html">Privacy &amp; Safety guide</a> lists safe habits
+        <a href="/guides/tts-privacy-safety.html">Privacy &amp; Safety guide</a> lists safe habits
         and explains why Read‑Aloud leans on local voices instead of cloud synthesis.
       </p>
     </div>
@@ -179,13 +178,13 @@
       <div class="card">
         <h3>Where to get full answers</h3>
         <p>
-          The <a href="help.html">Help Center</a> documents platform-specific fixes, including
+          The <a href="/help.html">Help Center</a> documents platform-specific fixes, including
           offline behavior, missing voices, and performance tips. You can also jump straight to the
-          <a href="voices.html">Voice Gallery</a> for OS-specific install steps or send a detailed
-          report through the <a href="contact.html">Contact page</a> using the bug report template.
+          <a href="/voices.html">Voice Gallery</a> for OS-specific install steps or send a detailed
+          report through the <a href="/contact.html">Contact page</a> using the bug report template.
         </p>
         <p>
-          If you prefer structured walkthroughs, start with the <a href="guides.html">Guides</a>
+          If you prefer structured walkthroughs, start with the <a href="/guides.html">Guides</a>
           collection. Each article ends with related links so you can dig deeper without searching
           around the site.
         </p>
@@ -203,11 +202,11 @@
         bottom of this site for clearer audio and fewer distractions.
       </p>
       <p>
-        Looking for a place to start? Visit the <a href="guides/tts-for-students.html">student
-        workflow guide</a>, try the <a href="guides/tts-voice-selection.html">voice selection
+        Looking for a place to start? Visit the <a href="/guides/tts-for-students.html">student
+        workflow guide</a>, try the <a href="/guides/tts-voice-selection.html">voice selection
         playbook</a>, or copy the prompts from the
-        <a href="guides/tts-study-loop-templates.html">study loop templates</a>. When you are ready
-        to listen, head to the <a href="app.html">Tool</a> and press Start.
+        <a href="/guides/tts-study-loop-templates.html">study loop templates</a>. When you are ready
+        to listen, head to the <a href="/app.html">Tool</a> and press Start.
       </p>
     </div>
   </section>
@@ -215,18 +214,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. As an Amazon Associate I earn from qualifying purchases.</div>
 </footer>

--- a/privacy.html
+++ b/privacy.html
@@ -29,19 +29,21 @@
   hr{margin:24px 0}
   code{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/privacy.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html" aria-current="page">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html" aria-current="page">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -145,7 +147,7 @@
   <h2>7) Contact</h2>
   <p>
     If you have privacy questions, email <strong>admin@read-aloud.com</strong> or use the
-    <a href="contact.html">contact form</a>.
+    <a href="/contact.html">contact form</a>.
   </p>
 
   <h2>8) Changes</h2>
@@ -155,16 +157,16 @@
 
   <hr>
   <p class="small">
-    Related: <a href="terms.html">Terms</a> · <a href="about.html">About</a> · <a href="guides.html">Guides</a>
+    Related: <a href="/terms.html">Terms</a> · <a href="/about.html">About</a> · <a href="/guides.html">Guides</a>
   </p>
 
   <p class="small">
-    © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="terms.html">Terms</a>
+    © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/terms.html">Terms</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -135,7 +135,7 @@
     </p>
   </div>
 
-  <h2>6) Your choices</h2>
+  <h2 id="controls">6) Your choices</h2>
   <ul>
     <li><strong>Don’t paste sensitive text</strong> on shared devices or while screen‑sharing.</li>
     <li>If ads are enabled in the future, you can use Google’s ad personalization controls (linked above).</li>

--- a/read-aloud-premium/public/premium.html
+++ b/read-aloud-premium/public/premium.html
@@ -14,17 +14,20 @@
     <meta charset="utf-8"/>
     <title>Premium Voices • read‑aloud</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content="Preview and purchase individual premium voice MP3 exports for Read‑Aloud when you need downloadable audio beyond the in-browser player." />
+    <link rel="canonical" href="https://read-aloud.com/read-aloud-premium/public/premium.html">
     <link rel="stylesheet" href="voices.css">
-  </head>
+    <link rel="stylesheet" href="/site.css">
+</head>
   <body>
 <header>
   <nav id="mainNav">
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html">Voices</a>
-    <a href="../about.html">About</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
   </nav>
 </header>
     <main class="wrap">
@@ -38,11 +41,11 @@
         This page is separate from the free Read‑Aloud tool and uses a different service endpoint. Use it
         only with text you have permission to convert. We do not store your text after generation, but you
         should still avoid regulated data. For everyday study sessions, stick with the free browser player
-        at <a href="../app.html">/app</a> so your text never leaves the device.
+        at <a href="/app.html">/app</a> so your text never leaves the device.
       </p>
       <p>
         Purchases are processed per file. If you run into an error, refresh the page and retry the preview
-        before regenerating the MP3. For billing questions, reach out via the <a href="../contact.html">contact form</a>
+        before regenerating the MP3. For billing questions, reach out via the <a href="/contact.html">contact form</a>
         with your transaction ID so we can help quickly.
       </p>
       <div id="actions">
@@ -80,7 +83,7 @@
     </main>
 
     <footer>
-  © 2025 Read‑Aloud · <a href="../contact.html">Contact</a> · <a href="../privacy.html">Privacy</a> · <a href="../terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 

--- a/read-aloud-premium/public/premium.html
+++ b/read-aloud-premium/public/premium.html
@@ -14,29 +14,36 @@
     <meta charset="utf-8"/>
     <title>Premium Voices • read‑aloud</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <!-- Reuse the shared stylesheet for consistent layout and styling -->
     <link rel="stylesheet" href="voices.css">
   </head>
   <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html">Voices</a>
+    <a href="../about.html">About</a>
   </nav>
 </header>
     <main class="wrap">
       <h1>Premium Voices</h1>
       <p>
-        Preview any voice for free. When you're ready to purchase a single
-        premium MP3, click <strong>Buy&nbsp;1 Premium MP3</strong>. After
-        payment you'll be able to enter your own text and download the
-        generated file.
+        Preview any voice for free. When you're ready to purchase a single premium MP3, click
+        <strong>Buy&nbsp;1 Premium MP3</strong>. After payment you'll be able to enter your own text and
+        download the generated file.
+      </p>
+      <p>
+        This page is separate from the free Read‑Aloud tool and uses a different service endpoint. Use it
+        only with text you have permission to convert. We do not store your text after generation, but you
+        should still avoid regulated data. For everyday study sessions, stick with the free browser player
+        at <a href="../app.html">/app</a> so your text never leaves the device.
+      </p>
+      <p>
+        Purchases are processed per file. If you run into an error, refresh the page and retry the preview
+        before regenerating the MP3. For billing questions, reach out via the <a href="../contact.html">contact form</a>
+        with your transaction ID so we can help quickly.
       </p>
       <div id="actions">
         <button id="buy">Buy 1 Premium MP3</button>
@@ -64,12 +71,16 @@
         <label for="genRate">Speed:</label>
         <input id="genRate" type="number" step="0.1" min="0.5" max="1.5" value="1.0">
       </div>
+      <p class="small">Tip: run a short preview first to ensure pronunciation matches your expectations.</p>
       <button id="generate">Generate MP3</button>
       <div id="download" style="margin-top: 16px;"></div>
+      <p class="small">Premium files are best for narrated videos or podcasts where you need a licenseable download. For homework or everyday reading, the free player remains simpler and faster.</p>
+      <p class="small">All purchases are single-use; if you need multiple clips, repeat the purchase after confirming each preview meets your needs.</p>
+      <p class="small">Pricing and availability can change; check this page for the latest options before budgeting a project.</p>
     </main>
 
     <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="../contact.html">Contact</a> · <a href="../privacy.html">Privacy</a> · <a href="../terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 

--- a/read-aloud-premium/public/voices.html
+++ b/read-aloud-premium/public/voices.html
@@ -19,19 +19,35 @@
   <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html" aria-current="page">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="../index.html">Home</a>
+    <a href="../app.html">Tool</a>
+    <a href="../guides.html">Guides</a>
+    <a href="../help.html">Help</a>
+    <a href="../voices.html" aria-current="page">Voices</a>
+    <a href="../about.html">About</a>
   </nav>
 </header>
     <main class="wrap">
       <h1>Voice Demos</h1>
       <p>Select a voice and click <strong>Play</strong> to hear a short sample. You can also provide your own text for the preview.</p>
+      <p>
+        These demos are powered by premium voices. They are separate from the free system voices used in
+        the <a href="../app.html">Read‑Aloud tool</a>, but the testing steps are similar: find a voice you
+        like, adjust speed, and confirm it fits your project. Demos stay on this page—your custom preview
+        text is not stored after you leave.
+      </p>
+      <p>
+        If you purchase a premium MP3, you will enter your text directly below. Please make sure you own
+        the rights to the material and avoid sensitive data. For day-to-day reading, the free tool with
+        local voices remains the recommended option.
+      </p>
+      <p>
+        Need help choosing a voice? Start with a short script from your project, try two speeds, and pick
+        the option that stays clear at both. If a preview stalls, reload the page to refresh the catalog of
+        available voices.
+      </p>
+      <p class="small">Looking for everyday listening? Head back to the <a href="../app.html">free tool</a> to use the system voices already on your device.</p>
+      <p class="small">We refresh this list as providers add new voices; check back if you do not see the accent you need today.</p>
       <div id="voice-list"></div>
       <div class="custom-text">
         <label for="customText">Custom preview text (optional):</label>
@@ -40,9 +56,11 @@
       <div class="player">
         <audio id="audio" controls preload="none"></audio>
       </div>
+      <p class="small">Note: premium demos stream from our provider; the free Read‑Aloud player uses local voices and keeps your text fully on-device.</p>
+      <p class="small">If you experience lag, pause other streaming tabs so the demo can buffer smoothly.</p>
     </main>
     <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="../contact.html">Contact</a> · <a href="../privacy.html">Privacy</a> · <a href="../terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 <script>window.API_BASE = 'https://api.read-aloud.com';</script>

--- a/read-aloud-premium/public/voices.html
+++ b/read-aloud-premium/public/voices.html
@@ -14,17 +14,20 @@
     <meta charset="utf-8"/>
     <title>Voice Demos • read‑aloud</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content="Preview premium voice demos for Read‑Aloud so you can hear pronunciation and tone before purchasing downloadable MP3 exports." />
     <link rel="stylesheet" href="voices.css">
-  </head>
+    <link rel="canonical" href="https://read-aloud.com/read-aloud-premium/public/voices.html">
+  <link rel="stylesheet" href="/site.css">
+</head>
   <body>
 <header>
   <nav id="mainNav">
-    <a href="../index.html">Home</a>
-    <a href="../app.html">Tool</a>
-    <a href="../guides.html">Guides</a>
-    <a href="../help.html">Help</a>
-    <a href="../voices.html" aria-current="page">Voices</a>
-    <a href="../about.html">About</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html" aria-current="page">Voices</a>
+    <a href="/about.html">About</a>
   </nav>
 </header>
     <main class="wrap">
@@ -32,7 +35,7 @@
       <p>Select a voice and click <strong>Play</strong> to hear a short sample. You can also provide your own text for the preview.</p>
       <p>
         These demos are powered by premium voices. They are separate from the free system voices used in
-        the <a href="../app.html">Read‑Aloud tool</a>, but the testing steps are similar: find a voice you
+        the <a href="/app.html">Read‑Aloud tool</a>, but the testing steps are similar: find a voice you
         like, adjust speed, and confirm it fits your project. Demos stay on this page—your custom preview
         text is not stored after you leave.
       </p>
@@ -46,7 +49,7 @@
         the option that stays clear at both. If a preview stalls, reload the page to refresh the catalog of
         available voices.
       </p>
-      <p class="small">Looking for everyday listening? Head back to the <a href="../app.html">free tool</a> to use the system voices already on your device.</p>
+      <p class="small">Looking for everyday listening? Head back to the <a href="/app.html">free tool</a> to use the system voices already on your device.</p>
       <p class="small">We refresh this list as providers add new voices; check back if you do not see the accent you need today.</p>
       <div id="voice-list"></div>
       <div class="custom-text">
@@ -60,7 +63,7 @@
       <p class="small">If you experience lag, pause other streaming tabs so the demo can buffer smoothly.</p>
     </main>
     <footer>
-  © 2025 Read‑Aloud · <a href="../contact.html">Contact</a> · <a href="../privacy.html">Privacy</a> · <a href="../terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 <script>window.API_BASE = 'https://api.read-aloud.com';</script>

--- a/recommendations.html
+++ b/recommendations.html
@@ -35,19 +35,21 @@
   .muted{color:#555}
   hr{margin:24px 0}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/recommendations.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html" aria-current="page">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html" aria-current="page">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
   </nav>
 </header>
 
@@ -318,7 +320,7 @@
   <h2>Suggestions / feedback</h2>
   <p class="small">
     If you have a specific recommendation request (budget, device, use-case), email me via the
-    <a href="contact.html">Contact</a> page and include your device (Windows/Mac/iPhone/Android) and your goal (study, proofreading, dyslexia support, language learning).
+    <a href="/contact.html">Contact</a> page and include your device (Windows/Mac/iPhone/Android) and your goal (study, proofreading, dyslexia support, language learning).
   </p>
 
   <p class="small">
@@ -326,7 +328,7 @@
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.read-aloud.com/sitemap.xml

--- a/scripts/content-audit.py
+++ b/scripts/content-audit.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Content audit helper for read-aloud.com.
+
+Scans HTML/Markdown files under the project directory, extracts visible text,
+counts words, and reports thin pages (<250 words).
+
+Usage:
+  python scripts/content-audit.py [--root PATH] [--output FILE]
+
+Examples:
+  python scripts/content-audit.py
+  python scripts/content-audit.py --root . --output scripts/reports/content-audit-before.txt
+"""
+import argparse
+import html
+import os
+import re
+from datetime import datetime
+from html.parser import HTMLParser
+from pathlib import Path
+
+EXTS = {".html", ".htm", ".md", ".mdx"}
+
+SCRIPT_RE = re.compile(r"<script.*?</script>", re.IGNORECASE | re.DOTALL)
+STYLE_RE = re.compile(r"<style.*?</style>", re.IGNORECASE | re.DOTALL)
+TITLE_RE = re.compile(r"<title>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+
+
+class TextExtractor(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.chunks = []
+
+    def handle_data(self, data):
+        cleaned = data.strip()
+        if cleaned:
+            self.chunks.append(cleaned)
+
+
+def extract_text(content: str) -> str:
+    """Remove scripts/styles and return visible text."""
+    content = SCRIPT_RE.sub(" ", content)
+    content = STYLE_RE.sub(" ", content)
+    parser = TextExtractor()
+    parser.feed(content)
+    return " ".join(parser.chunks)
+
+
+def extract_title(content: str, suffix: str) -> str:
+    match = TITLE_RE.search(content)
+    if match:
+        return html.unescape(match.group(1)).strip()
+    # Fallback for Markdown
+    for line in content.splitlines():
+        if line.startswith("#"):
+            return line.lstrip("# ").strip()
+    return f"(untitled {suffix})"
+
+
+def scan(root: Path):
+    rows = []
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.suffix.lower() in EXTS:
+            rel = path.relative_to(root)
+            try:
+                text = extract_text(path.read_text(encoding="utf-8"))
+            except UnicodeDecodeError:
+                text = extract_text(path.read_text(errors="ignore"))
+            title = extract_title(path.read_text(encoding="utf-8", errors="ignore"), path.name)
+            words = len([w for w in re.split(r"\s+", text) if w])
+            mtime = datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds")
+            thin = words < 250
+            rows.append((str(rel).replace(os.sep, "/"), title, words, mtime, thin))
+    return rows
+
+
+def format_report(rows):
+    lines = ["PATH | WORDS | THIN? | TITLE | LAST MODIFIED", "-" * 90]
+    for rel, title, words, mtime, thin in rows:
+        label = "YES" if thin else "NO"
+        lines.append(f"{rel} | {words} | {label} | {title} | {mtime}")
+    thin_count = sum(1 for r in rows if r[4])
+    lines.append("-" * 90)
+    lines.append(f"Total files: {len(rows)} — Thin pages: {thin_count}")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Audit visible text on public pages.")
+    parser.add_argument("--root", default=".", help="Root directory to scan (default: current).")
+    parser.add_argument("--output", help="Optional path to write the report.")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    rows = scan(root)
+    report = format_report(rows)
+    print(report)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(report, encoding="utf-8")
+        print(f"\nSaved report to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reports/content-audit-after.txt
+++ b/scripts/reports/content-audit-after.txt
@@ -1,0 +1,45 @@
+PATH | WORDS | THIN? | TITLE | LAST MODIFIED
+------------------------------------------------------------------------------------------
+Uses/proofreading.html | 262 | NO | Proofread by Ear | Read‑Aloud | 2026-01-01T14:57:12
+Uses/study.html | 304 | NO | Study Better With Text-to-Speech | Read-Aloud | 2026-01-01T14:46:18
+about.html | 534 | NO | About Read‑Aloud | Why It Exists and Where It’s Going | 2026-01-01T14:50:30
+app.html | 277 | NO | Use the Read‑Aloud Tool | Browser Text-to-Speech | 2026-01-01T14:49:37
+audio.html | 262 | NO | Audio Samples & Streams | Read‑Aloud | 2026-01-01T14:56:36
+benefits.html | 267 | NO | Benefits of Read‑Aloud | Why Use Browser-Based TTS | 2026-01-01T14:53:22
+benifits.html | 260 | NO | Benefits of Read‑Aloud (Yes, You Spelled It Right) | 2026-01-01T14:57:45
+blog.html | 256 | NO | Product Updates | Read‑Aloud | 2026-01-01T14:55:40
+bookmark.html | 255 | NO | Bookmark Read‑Aloud | Quick Access Instructions | 2026-01-01T14:55:43
+contact.html | 261 | NO | Contact | Read‑Aloud Support | 2026-01-01T14:50:17
+download-mp3.html | 276 | NO | Why MP3 Export Is Limited | Read‑Aloud | 2026-01-01T14:55:46
+faq.html | 259 | NO | FAQ | Read‑Aloud | 2026-01-01T14:46:18
+guide-browser-compatibility.html | 539 | NO | Browser Compatibility & Voice Availability | Read‑Aloud | 2026-01-01T14:46:18
+guide-dyslexia-adhd.html | 519 | NO | Text‑to‑Speech for Dyslexia & ADHD | Read‑Aloud | 2026-01-01T14:46:18
+guide-how-to-use.html | 422 | NO | How to Use Read‑Aloud (Step‑by‑Step) | Read‑Aloud | 2026-01-01T14:46:18
+guide-language-learning.html | 556 | NO | Language Learning with Text‑to‑Speech | Read‑Aloud | 2026-01-01T14:46:18
+guide-mp3-export.html | 417 | NO | Why MP3 Export Is Hard in Browser TTS | Read‑Aloud | 2026-01-01T14:46:18
+guide-privacy.html | 452 | NO | Privacy‑First Text‑to‑Speech | Read‑Aloud | 2026-01-01T14:46:18
+guide-proofread.html | 525 | NO | Proofread by Ear (Text‑to‑Speech Editing) | Read‑Aloud | 2026-01-01T14:46:18
+guide-study.html | 602 | NO | Study With Text‑to‑Speech | Read‑Aloud | 2026-01-01T14:46:18
+guides/tts-for-adhd-focus.html | 587 | NO | TTS for Focus: Chunking + Timers + Speed Settings for ADHD Brains | 2026-01-01T14:51:38
+guides/tts-for-dyslexia-support.html | 540 | NO | Dyslexia-Friendly Reading with TTS: Setup, Pacing, and Dual Reading | 2026-01-01T14:51:51
+guides/tts-for-language-shadowing.html | 476 | NO | Shadowing Practice with TTS: Scripts, Routines, and How to Track Progress | 2026-01-01T14:52:05
+guides/tts-for-students.html | 827 | NO | Text-to-Speech for Students: A Practical Workflow That Actually Improves Grades | 2026-01-01T14:51:06
+guides/tts-for-writers.html | 690 | NO | Text-to-Speech for Writers: A Proofreading Process That Finds the Mistakes Your Eyes Miss | 2026-01-01T14:51:22
+guides/tts-privacy-safety.html | 425 | NO | Privacy & Safety: What Not to Paste, How Local Voices Work, and Safer Habits | 2026-01-01T14:52:48
+guides/tts-study-loop-templates.html | 404 | NO | Copy/Paste Templates: Study Loops, Active Recall Prompts, and Listening Checklists | 2026-01-01T14:52:34
+guides/tts-voice-selection.html | 445 | NO | How to Choose the Best Voice: Comfort, Fatigue, and Comprehension | 2026-01-01T14:52:19
+guides-how-to-use.html | 512 | NO | How to Use Read‑Aloud (Step‑by‑Step) | Read‑Aloud | 2026-01-01T14:46:18
+guides.html | 271 | NO | Guides & Tutorials | Read‑Aloud | 2026-01-01T14:55:48
+help.html | 853 | NO | Help Center | Read‑Aloud Troubleshooting | 2026-01-01T14:49:55
+how-it-works.html | 301 | NO | How Read‑Aloud Works | 2026-01-01T14:54:06
+index.html | 1003 | NO | Read‑Aloud | Free Text-to-Speech for Everyday Reading | 2026-01-01T14:49:21
+privacy.html | 609 | NO | Privacy Policy | Read‑Aloud | 2026-01-01T14:55:22
+read-aloud-premium/public/premium.html | 259 | NO | Premium Voices • read‑aloud | 2026-01-01T14:57:18
+read-aloud-premium/public/voices.html | 262 | NO | Voice Demos • read‑aloud | 2026-01-01T14:57:40
+recommendations.html | 963 | NO | Recommended Reading Aids & Accessories | Read‑Aloud | 2026-01-01T14:46:18
+support.html | 251 | NO | Support | Read‑Aloud | 2026-01-01T14:57:37
+terms.html | 735 | NO | Terms of Use | Read‑Aloud | 2026-01-01T14:46:18
+texttospeech.html | 259 | NO | Text-to-Speech Reader | Redirect to the Read‑Aloud Tool | 2026-01-01T14:57:27
+voices.html | 564 | NO | Voice Gallery | System Voices and How to Add More | 2026-01-01T14:50:08
+------------------------------------------------------------------------------------------
+Total files: 41 — Thin pages: 0

--- a/scripts/reports/content-audit-before.txt
+++ b/scripts/reports/content-audit-before.txt
@@ -1,0 +1,36 @@
+PATH | WORDS | THIN? | TITLE | LAST MODIFIED
+------------------------------------------------------------------------------------------
+Uses/proofreading.html | 226 | YES | Proofread by Ear | Read-Aloud | 2026-01-01T14:46:18
+Uses/study.html | 304 | NO | Study Better With Text-to-Speech | Read-Aloud | 2026-01-01T14:46:18
+about.html | 500 | NO | About | Read‑Aloud | 2026-01-01T14:46:18
+audio.html | 39 | YES | Audio Stream | 2026-01-01T14:46:18
+benefits.html | 99 | YES | Benefits | Read-Aloud | 2026-01-01T14:46:18
+benifits.html | 99 | YES | Benefits | Read-Aloud | 2026-01-01T14:46:18
+blog.html | 181 | YES | Blog | Read-Aloud | 2026-01-01T14:46:18
+bookmark.html | 65 | YES | Text-to-Speech Website | 2026-01-01T14:46:18
+contact.html | 54 | YES | Contact | Read-Aloud | 2026-01-01T14:46:18
+download-mp3.html | 195 | YES | Download MP3 (Offline Voice) · Read‑Aloud | 2026-01-01T14:46:18
+faq.html | 259 | NO | FAQ | Read‑Aloud | 2026-01-01T14:46:18
+guide-browser-compatibility.html | 539 | NO | Browser Compatibility & Voice Availability | Read‑Aloud | 2026-01-01T14:46:18
+guide-dyslexia-adhd.html | 519 | NO | Text‑to‑Speech for Dyslexia & ADHD | Read‑Aloud | 2026-01-01T14:46:18
+guide-how-to-use.html | 422 | NO | How to Use Read‑Aloud (Step‑by‑Step) | Read‑Aloud | 2026-01-01T14:46:18
+guide-language-learning.html | 556 | NO | Language Learning with Text‑to‑Speech | Read‑Aloud | 2026-01-01T14:46:18
+guide-mp3-export.html | 417 | NO | Why MP3 Export Is Hard in Browser TTS | Read‑Aloud | 2026-01-01T14:46:18
+guide-privacy.html | 452 | NO | Privacy‑First Text‑to‑Speech | Read‑Aloud | 2026-01-01T14:46:18
+guide-proofread.html | 525 | NO | Proofread by Ear (Text‑to‑Speech Editing) | Read‑Aloud | 2026-01-01T14:46:18
+guide-study.html | 602 | NO | Study With Text‑to‑Speech | Read‑Aloud | 2026-01-01T14:46:18
+guides-how-to-use.html | 512 | NO | How to Use Read‑Aloud (Step‑by‑Step) | Read‑Aloud | 2026-01-01T14:46:18
+guides.html | 336 | NO | Guides & Tutorials | Read‑Aloud | 2026-01-01T14:46:18
+help.html | 232 | YES | Help & FAQ | Read-Aloud | 2026-01-01T14:46:18
+how-it-works.html | 85 | YES | How It Works | Read-Aloud | 2026-01-01T14:46:18
+index.html | 177 | YES | Read-Aloud | FREE Text-to-Speech | 2026-01-01T14:46:18
+privacy.html | 609 | NO | Privacy Policy | Read‑Aloud | 2026-01-01T14:46:18
+read-aloud-premium/public/premium.html | 88 | YES | Premium Voices • read‑aloud | 2026-01-01T14:46:18
+read-aloud-premium/public/voices.html | 57 | YES | Voice Demos • read‑aloud | 2026-01-01T14:46:18
+recommendations.html | 963 | NO | Recommended Reading Aids & Accessories | Read‑Aloud | 2026-01-01T14:46:18
+support.html | 37 | YES | Contact | Read-Aloud | 2026-01-01T14:46:18
+terms.html | 735 | NO | Terms of Use | Read‑Aloud | 2026-01-01T14:46:18
+texttospeech.html | 68 | YES | Text-to-Speech Website | 2026-01-01T14:46:18
+voices.html | 104 | YES | Voice Gallery | Read-Aloud | 2026-01-01T14:46:18
+------------------------------------------------------------------------------------------
+Total files: 32 — Thin pages: 16

--- a/site.css
+++ b/site.css
@@ -1,0 +1,138 @@
+:root {
+  --bg: #f7f9fc;
+  --text: #111827;
+  --muted: #4b5563;
+  --accent: #0f4aad;
+  --accent-soft: #e5eeff;
+  --card: #ffffff;
+  --border: #d7deea;
+  --shadow: 0 10px 35px rgba(15, 74, 173, 0.08);
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.7;
+}
+a { color: var(--accent); }
+a:hover, a:focus { text-decoration: underline; }
+
+header {
+  background: #0c2f63;
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 3px 14px rgba(0,0,0,0.1);
+}
+.navbar {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 14px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.logo { font-weight: 800; letter-spacing: 0.5px; font-size: 1.1rem; }
+.nav-links { display: flex; flex-wrap: wrap; gap: 14px; }
+.nav-links a {
+  color: #e8efff;
+  text-decoration: none;
+  padding: 8px 10px;
+  border-radius: 8px;
+}
+.nav-links a[aria-current="page"] { background: rgba(255,255,255,0.14); }
+.nav-links a:hover { background: rgba(255,255,255,0.2); }
+
+main { max-width: 1100px; margin: 0 auto; padding: 32px 20px 48px; }
+.hero {
+  background: linear-gradient(135deg, #0f4aad, #174f9f 55%, #0a2f6f);
+  color: #fff;
+  padding: 32px;
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+}
+.hero h1 { margin-top: 0; font-size: 2.4rem; }
+.hero p { color: #e9f1ff; max-width: 820px; }
+
+section { margin-top: 36px; }
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: var(--shadow);
+}
+.grid { display: grid; gap: 18px; }
+.two-col { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.three-col { grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); }
+
+.tag { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-soft); color: var(--accent); font-weight: 600; }
+.lead { font-size: 1.1rem; color: var(--muted); }
+.small { color: var(--muted); font-size: 0.95rem; }
+
+footer {
+  background: #0c2f63;
+  color: #e8efff;
+  padding: 20px;
+  margin-top: 40px;
+}
+footer a { color: #e8efff; text-decoration: none; margin-right: 12px; }
+footer a:hover { text-decoration: underline; }
+footer .legal { font-size: 0.95rem; color: #ced9f5; margin-top: 6px; }
+
+.breadcrumb { font-size: 0.95rem; color: var(--muted); margin-bottom: 16px; }
+.breadcrumb a { color: var(--accent); text-decoration: none; }
+.breadcrumb span { color: var(--muted); }
+
+.related {
+  margin-top: 32px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.related h3 { margin-top: 0; }
+.related ul { padding-left: 18px; }
+
+.callout {
+  background: #f0f5ff;
+  border: 1px solid #cfe0ff;
+  padding: 14px 16px;
+  border-radius: 12px;
+}
+
+.table-of-contents ul { padding-left: 20px; }
+.table-of-contents li { margin: 6px 0; }
+
+.table { width: 100%; border-collapse: collapse; }
+.table th, .table td { border: 1px solid var(--border); padding: 10px; text-align: left; }
+.table th { background: #eef3fc; }
+
+.app-grid { display: grid; gap: 18px; grid-template-columns: 2fr 1fr; }
+@media (max-width: 980px) { .app-grid { grid-template-columns: 1fr; } }
+
+textarea, select, input, button { font: inherit; }
+.button-primary {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+.button-primary:hover { background: #0b3a86; }
+
+.note {
+  background: #fffaf0;
+  border: 1px solid #f4d38b;
+  border-radius: 12px;
+  padding: 12px 14px;
+}
+
+figure { margin: 0; }
+
+.guide-meta { color: var(--muted); font-size: 0.95rem; margin-bottom: 16px; }
+.guide-section h2 { margin-top: 0; }

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,9 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://www.read-aloud.com/</loc>
-    <lastmod>2025-01-20</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>1.0</priority>
-  </url>
+  <url><loc>https://www.read-aloud.com/</loc></url>
+  <url><loc>https://www.read-aloud.com/app.html</loc></url>
+  <url><loc>https://www.read-aloud.com/guides.html</loc></url>
+  <url><loc>https://www.read-aloud.com/help.html</loc></url>
+  <url><loc>https://www.read-aloud.com/voices.html</loc></url>
+  <url><loc>https://www.read-aloud.com/about.html</loc></url>
+  <url><loc>https://www.read-aloud.com/contact.html</loc></url>
+  <url><loc>https://www.read-aloud.com/privacy.html</loc></url>
+  <url><loc>https://www.read-aloud.com/terms.html</loc></url>
+  <url><loc>https://www.read-aloud.com/recommendations.html</loc></url>
+  <url><loc>https://www.read-aloud.com/benefits.html</loc></url>
+  <url><loc>https://www.read-aloud.com/blog.html</loc></url>
+  <url><loc>https://www.read-aloud.com/bookmark.html</loc></url>
+  <url><loc>https://www.read-aloud.com/download-mp3.html</loc></url>
+  <url><loc>https://www.read-aloud.com/how-it-works.html</loc></url>
+  <url><loc>https://www.read-aloud.com/support.html</loc></url>
+  <url><loc>https://www.read-aloud.com/Uses/proofreading.html</loc></url>
+  <url><loc>https://www.read-aloud.com/guides/tts-for-students.html</loc></url>
+  <url><loc>https://www.read-aloud.com/guides/tts-for-writers.html</loc></url>
+  <url><loc>https://www.read-aloud.com/guides/tts-for-adhd-focus.html</loc></url>
+  <url><loc>https://www.read-aloud.com/guides/tts-for-dyslexia-support.html</loc></url>
+  <url><loc>https://www.read-aloud.com/guides/tts-for-language-shadowing.html</loc></url>
+  <url><loc>https://www.read-aloud.com/guides/tts-voice-selection.html</loc></url>
+  <url><loc>https://www.read-aloud.com/guides/tts-study-loop-templates.html</loc></url>
+  <url><loc>https://www.read-aloud.com/guides/tts-privacy-safety.html</loc></url>
 </urlset>

--- a/support.html
+++ b/support.html
@@ -3,47 +3,46 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Support | Read‑Aloud</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Get support for Read‑Aloud. Links to the Help Center, Contact page, and troubleshooting checklists." />
-  <link rel="canonical" href="https://www.read-aloud.com/support.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/support.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Support</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Support</div>
   <h1>Support</h1>
   <p class="lead">Start with the Help Center for step-by-step fixes. If you still need assistance, send a detailed report.</p>
 
   <section class="card">
     <h2>Self-serve resources</h2>
     <ul>
-      <li><a href="help.html">Help Center</a> — platform-specific checklists for no sound, missing voices, and offline use.</li>
-      <li><a href="voices.html">Voice Gallery</a> — instructions for adding system voices on iOS, macOS, Windows, and Android.</li>
-      <li><a href="guides.html">Guides</a> — full workflows for students, writers, and accessibility needs.</li>
+      <li><a href="/help.html">Help Center</a> — platform-specific checklists for no sound, missing voices, and offline use.</li>
+      <li><a href="/voices.html">Voice Gallery</a> — instructions for adding system voices on iOS, macOS, Windows, and Android.</li>
+      <li><a href="/guides.html">Guides</a> — full workflows for students, writers, and accessibility needs.</li>
     </ul>
     <p class="small">Tip: keep <a href="help.html#iphone-ipad">the iPhone/iPad checklist</a> bookmarked if you switch devices often.</p>
   </section>
 
   <section class="card">
     <h2>Contact us</h2>
-    <p>Use the <a href="contact.html">Contact page</a> and include browser, device, what happened, and a short snippet of the text length you tried. Most replies arrive within two business days.</p>
+    <p>Use the <a href="/contact.html">Contact page</a> and include browser, device, what happened, and a short snippet of the text length you tried. Most replies arrive within two business days.</p>
     <p>If you are reporting a classroom or accessibility issue, mention deadlines or accommodation details so we can prioritize correctly.</p>
     <p>For billing questions about premium MP3s, include your transaction ID and the voice you selected. Technical questions about the free tool are handled first to keep the site reliable for everyone.</p>
   </section>
@@ -58,18 +57,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Help is one click away.</div>
 </footer>

--- a/support.html
+++ b/support.html
@@ -1,46 +1,77 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-<meta charset="utf-8"><title>Contact | Read-Aloud</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<style>
-body{font-family:Arial,sans-serif;margin:2rem}
-form{max-width:500px}
-.small{font-size:0.9em;color:#444;margin-top:16px}
-</style>
-</head><body>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Support | Read‑Aloud</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Get support for Read‑Aloud. Links to the Help Center, Contact page, and troubleshooting checklists." />
+  <link rel="canonical" href="https://www.read-aloud.com/support.html">
+  <link rel="stylesheet" href="site.css">
+</head>
+<body>
 <header>
-  <nav id="mainNav">
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Support</div>
+  <h1>Support</h1>
+  <p class="lead">Start with the Help Center for step-by-step fixes. If you still need assistance, send a detailed report.</p>
+
+  <section class="card">
+    <h2>Self-serve resources</h2>
+    <ul>
+      <li><a href="help.html">Help Center</a> — platform-specific checklists for no sound, missing voices, and offline use.</li>
+      <li><a href="voices.html">Voice Gallery</a> — instructions for adding system voices on iOS, macOS, Windows, and Android.</li>
+      <li><a href="guides.html">Guides</a> — full workflows for students, writers, and accessibility needs.</li>
+    </ul>
+    <p class="small">Tip: keep <a href="help.html#iphone-ipad">the iPhone/iPad checklist</a> bookmarked if you switch devices often.</p>
+  </section>
+
+  <section class="card">
+    <h2>Contact us</h2>
+    <p>Use the <a href="contact.html">Contact page</a> and include browser, device, what happened, and a short snippet of the text length you tried. Most replies arrive within two business days.</p>
+    <p>If you are reporting a classroom or accessibility issue, mention deadlines or accommodation details so we can prioritize correctly.</p>
+    <p>For billing questions about premium MP3s, include your transaction ID and the voice you selected. Technical questions about the free tool are handled first to keep the site reliable for everyone.</p>
+  </section>
+
+  <section class="card">
+    <h2>Service status</h2>
+    <p>Read‑Aloud is a static site; outages are rare. If the page fails to load, check your network or try a different browser profile. Known issues, if any, will be posted on the <a href="blog.html">Product Updates</a> page.</p>
+    <p class="small">If audio works elsewhere but not here, see the <a href="help.html#iphone-ipad">platform checklists</a> before writing in.</p>
+    <p class="small">For campus networks that block audio streams, switch to mobile data for the first playback to grant audio permission.</p>
+  </section>
+</main>
+
+<footer>
+  <div>
     <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
+    <a href="app.html">Tool</a>
     <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
     <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
     <a href="privacy.html">Privacy</a>
     <a href="terms.html">Terms</a>
-  </nav>
-</header>
-<h1>Contact Us</h1>
-<form action="https://formspree.io/f/yourFormID" method="POST">
-<label>Name<br><input type="text" name="name" required></label><br><br>
-<label>Email<br><input type="email" name="_replyto" required></label><br><br>
-<label>Message<br><textarea name="message" rows="6" required></textarea></label><br><br>
-<button type="submit">Send</button>
-</form>
-<p>Email: support@read-aloud.com</p>
-<footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Help is one click away.</div>
 </footer>
-</body></html>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -29,19 +29,21 @@
   hr{margin:24px 0}
   code{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace}
 </style>
+  <link rel="canonical" href="https://read-aloud.com/terms.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 
 <body>
 <header>
   <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html" aria-current="page">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/help.html">Help</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/recommendations.html">Recommendations</a>
+    <a href="/about.html">About</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html" aria-current="page">Terms</a>
   </nav>
 </header>
 
@@ -112,7 +114,7 @@
   <p>
     Read‑Aloud may display ads at some times and not at others (for example, depending on approval status, configuration, or region).
     If ads are enabled, they may be served by third‑party providers and subject to their policies.
-    See <a href="privacy.html">Privacy Policy</a> for more details about third‑party technologies.
+    See <a href="/privacy.html">Privacy Policy</a> for more details about third‑party technologies.
   </p>
 
   <h2>8) Availability and changes to the service</h2>
@@ -158,17 +160,17 @@
   <h2>13) Contact</h2>
   <p>
     Questions about these Terms? Email <strong>admin@read-aloud.com</strong> or use the
-    <a href="contact.html">contact form</a>.
+    <a href="/contact.html">contact form</a>.
   </p>
 
   <hr>
   <p class="small">
-    Related: <a href="privacy.html">Privacy Policy</a> · <a href="about.html">About</a> · <a href="help.html">Help</a>
+    Related: <a href="/privacy.html">Privacy Policy</a> · <a href="/about.html">About</a> · <a href="/help.html">Help</a>
   </p>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
+  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
   <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
 </footer>
 </body>

--- a/texttospeech.html
+++ b/texttospeech.html
@@ -3,33 +3,32 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Text-to-Speech Reader | Redirect to the Read‑Aloud Tool</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Use the Read‑Aloud tool at /app for the latest text-to-speech experience. Learn what changed and why the tool moved." />
-  <link rel="canonical" href="https://www.read-aloud.com/texttospeech.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/texttospeech.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Text-to-Speech</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Text-to-Speech</div>
   <h1>Looking for the Text-to-Speech Reader?</h1>
-  <p class="lead">The Read‑Aloud tool now lives at <a href="app.html">/app</a>. We moved it to keep ads away from user-pasted text and to make room for a content-rich homepage.</p>
+  <p class="lead">The Read‑Aloud tool now lives at <a href="/app.html">/app</a>. We moved it to keep ads away from user-pasted text and to make room for a content-rich homepage.</p>
   <p class="card">This page remains as a waypoint for older bookmarks. You can still learn what changed and why the experience is now split between a content-rich landing page and a focused player.</p>
 
   <section class="card">
@@ -49,7 +48,7 @@
 
   <section class="card">
     <h2>Start listening</h2>
-    <p>Head to the <a href="app.html">tool</a>, paste your text, and press Start. If you bookmarked this old URL, update your bookmark using the steps on the <a href="bookmark.html">bookmark guide</a>.</p>
+    <p>Head to the <a href="/app.html">tool</a>, paste your text, and press Start. If you bookmarked this old URL, update your bookmark using the steps on the <a href="bookmark.html">bookmark guide</a>.</p>
     <p>If you run into issues after switching, clear this old tab and open the tool fresh. All keyboard shortcuts and privacy defaults remain the same.</p>
     <p class="small">Your pasted text stays local; the move to /app did not change that privacy promise.</p>
   </section>
@@ -57,18 +56,18 @@
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Please update your bookmark to /app.</div>
 </footer>

--- a/texttospeech.html
+++ b/texttospeech.html
@@ -1,320 +1,76 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Text-to-Speech Website</title>
-    <link rel="stylesheet" href="styles.css">
-<script src="https://unpkg.com/mespeak/mespeak.min.js"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-SVGML1VGPG');</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Text-to-Speech Reader | Redirect to the Read‑Aloud Tool</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Use the Read‑Aloud tool at /app for the latest text-to-speech experience. Learn what changed and why the tool moved." />
+  <link rel="canonical" href="https://www.read-aloud.com/texttospeech.html">
+  <link rel="stylesheet" href="site.css">
 </head>
 <body>
 <header>
-  <nav id="mainNav">
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Text-to-Speech</div>
+  <h1>Looking for the Text-to-Speech Reader?</h1>
+  <p class="lead">The Read‑Aloud tool now lives at <a href="app.html">/app</a>. We moved it to keep ads away from user-pasted text and to make room for a content-rich homepage.</p>
+  <p class="card">This page remains as a waypoint for older bookmarks. You can still learn what changed and why the experience is now split between a content-rich landing page and a focused player.</p>
+
+  <section class="card">
+    <h2>Why the move?</h2>
+    <p>Separating the tool from the landing page keeps the listening experience clean and focused. It also lets us explain privacy, voice setup, and troubleshooting on the homepage without cluttering the player.</p>
+  </section>
+
+  <section class="card">
+    <h2>What changed</h2>
+    <ul>
+      <li>Same controls and keyboard shortcuts, now in a dedicated layout.</li>
+      <li>New sidebar tips for privacy and copyright reminders.</li>
+      <li>Ads removed from the tool page; they remain on content pages like guides.</li>
+    </ul>
+    <p class="small">If you bookmarked the old retro design for nostalgia, you can still find the same functionality—just faster and better organized.</p>
+  </section>
+
+  <section class="card">
+    <h2>Start listening</h2>
+    <p>Head to the <a href="app.html">tool</a>, paste your text, and press Start. If you bookmarked this old URL, update your bookmark using the steps on the <a href="bookmark.html">bookmark guide</a>.</p>
+    <p>If you run into issues after switching, clear this old tab and open the tool fresh. All keyboard shortcuts and privacy defaults remain the same.</p>
+    <p class="small">Your pasted text stays local; the move to /app did not change that privacy promise.</p>
+  </section>
+</main>
+
+<footer>
+  <div>
     <a href="index.html">Home</a>
-    <a href="voices.html">Voices</a>
-    <a href="help.html">Help</a>
+    <a href="app.html">Tool</a>
     <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html">Voices</a>
     <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
     <a href="privacy.html">Privacy</a>
     <a href="terms.html">Terms</a>
-  </nav>
-</header>
-    <h1>Text-to-Speech Reader</h1>
-    <p>Type or paste your text below to hear it read aloud.</p>
-
-    <textarea id="textInput" placeholder="Type or paste your text here..."></textarea>
-    <br>
-
-    <label for="languageSelect">Select Language:</label>
-    <select id="languageSelect" onchange="filterVoicesByLanguage()">
-        <option value="en" selected>English</option>
-        <option value="es">Spanish</option>
-        <option value="fr">French</option>
-        <option value="de">German</option>
-        <option value="it">Italian</option>
-    </select>
-    <br>
-
-    <label for="voiceSelect">Select Voice:</label>
-    <select id="voiceSelect">
-        <option value="-1">Default Voice (Fallback)</option>
-    </select>
-
-    <label for="rateControl">Reading Speed:</label>
-    <input type="range" id="rateControl" min="0.5" max="2" step="0.1" value="1" onchange="updateRate(this.value)">
-    <span id="rateValue">1</span>
-
-    <div class="button-container">
-        <button onclick="startReading(true)">Start</button>
-        <button onclick="pauseReading()">Pause</button>
-        <button onclick="resumeReading()">Resume</button>
-        <button onclick="stopReading()">Stop</button>
-    </div>
-
-    <div id="textDisplay"></div>
-
-    <div id="progressContainer">
-        <div class="progress-details">
-            <p><strong>Progress:</strong> <span id="progressPercent">0%</span></p>
-            <p><strong>Time Elapsed:</strong> <span id="timeElapsed">00:00:00</span></p>
-            <p><strong>Time Remaining:</strong> <span id="timeRemaining">00:00:00</span></p>
-        </div>
-    </div>
-
-    <script>
-        let speechSynthesisUtterance;
-        let voices = [];
-        let startWordIndex = 0;
-        let previousText = "";
-        let readingStartTime = null;
-        let cachedSpans = null; // Cache spans for performance optimization
-
-window.mespeakLoaded=false;
-mespeak.loadConfig("https://unpkg.com/mespeak/mespeak_config.json");
-mespeak.loadVoice("https://unpkg.com/mespeak/voices/en/en.json",()=>{window.mespeakLoaded=true;});
-
-        const textDisplay = document.getElementById('textDisplay');
-        const textInput = document.getElementById('textInput');
-        const voicesDropdown = document.getElementById('voiceSelect');
-        const languageDropdown = document.getElementById('languageSelect');
-        const rateControl = document.getElementById('rateControl');
-        const rateValue = document.getElementById('rateValue');
-
-        const progressPercent = document.getElementById('progressPercent');
-        const timeElapsed = document.getElementById('timeElapsed');
-        const timeRemaining = document.getElementById('timeRemaining');
-
-        const regionalVoicePriority = {
-            "en-US": ["Samantha", "Alex"],
-            "en-GB": ["Daniel", "Serena", "Moira"],
-            "en-AU": ["Karen", "Russell"],
-            "fr-FR": ["Thomas", "Audrey"],
-            "de-DE": ["Hans", "Marlene"],
-            "it-IT": ["Alice", "Luca"],
-        };
-
-        let excludedVoices = [];
-
-        function updateExcludedVoices(newExclusions) {
-            excludedVoices = newExclusions;
-        }
-
-        updateExcludedVoices(["Jester", "Organ", "Bubbles", "Bad News", "Boing", "Wobble", "Grandma", "Grandpa", "Rocko", "Shelley", "Flo", "Eddy", "Reed"]);
-
-        function precomputeVoiceFilters(selectedLanguage) {
-            const prioritizedVoices = regionalVoicePriority[selectedLanguage + "-US"] || [];
-            const filteredVoices = {
-                prioritized: [],
-                fallback: []
-            };
-
-            voices.forEach((voice, index) => {
-                if (excludedVoices.some(excluded => voice.name.includes(excluded))) {
-                    return;
-                }
-                if (prioritizedVoices.includes(voice.name)) {
-                    filteredVoices.prioritized.push({
-                        index,
-                        html: `<option value="${index}" selected>🌟 ${voice.name} (${voice.lang})</option>`
-                    });
-                } else if (voice.lang.startsWith(selectedLanguage)) {
-                    filteredVoices.fallback.push({
-                        index,
-                        html: `<option value="${index}">${voice.name} (${voice.lang})</option>`
-                    });
-                }
-            });
-
-            return filteredVoices;
-        }
-
-        function filterVoicesByLanguage() {
-            const selectedLanguage = languageDropdown.value;
-            const { prioritized, fallback } = precomputeVoiceFilters(selectedLanguage);
-
-            voicesDropdown.innerHTML = `<option value="-1">Default Voice (Fallback)</option>` +
-                prioritized.map(v => v.html).join('') +
-                fallback.map(v => v.html).join('');
-        }
-
-        function updateTextDisplay() {
-            const text = textInput.value;
-            if (text !== previousText) {
-                const words = text.split(/(\s+)/);
-                textDisplay.innerHTML = words
-                    .map((word, index) => `<span data-index="${index}">${word}</span>`)
-                    .join('');
-                textDisplay.style.display = 'block';
-                previousText = text;
-                cachedSpans = textDisplay.querySelectorAll('span'); // Cache spans
-                attachClickHandlers();
-            }
-        }
-
-        function attachClickHandlers() {
-            cachedSpans.forEach(span => {
-                span.addEventListener('click', () => {
-                    const index = parseInt(span.getAttribute('data-index'), 10);
-                    startWordIndex = index;
-                    if (speechSynthesis.speaking) {
-                        speechSynthesis.cancel();
-                    }
-                    highlightWord(index); // Immediately highlight selected word
-                    startReading(false);
-                });
-            });
-        }
-
-        function highlightWord(index) {
-            cachedSpans.forEach(span => span.classList.remove('highlight'));
-            if (cachedSpans[index]) {
-                cachedSpans[index].classList.add('highlight');
-            }
-        }
-
-        function formatTime(seconds) {
-            const hrs = Math.floor(seconds / 3600).toString().padStart(2, '0');
-            const mins = Math.floor((seconds % 3600) / 60).toString().padStart(2, '0');
-            const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
-            return `${hrs}:${mins}:${secs}`;
-        }
-
-        function updateProgress(currentWordIndex, totalWords) {
-            const percent = Math.round((currentWordIndex / totalWords) * 100);
-            progressPercent.textContent = `${percent}%`;
-
-            const elapsedTime = Math.floor((Date.now() - readingStartTime) / 1000);
-            const estimatedTime = Math.round((totalWords - currentWordIndex) / 2);
-
-            timeElapsed.textContent = formatTime(elapsedTime);
-            timeRemaining.textContent = formatTime(estimatedTime);
-        }
-
-        function startReading(reset = false) {
-            const text = textInput.value;
-
-            if (!text) {
-                alert('Please enter some text to read aloud.');
-                return;
-            }
-
-            if(voices.length===0 || voicesDropdown.value==='-1'){
-                mespeak.speak(text,{speed:parseFloat(rateControl.value)*175});
-                return;
-            }
-
-            if (reset) {
-                startWordIndex = 0;
-                resetProgress();
-            }
-
-            const words = text.split(/(\s+)/);
-            const selectedText = words.slice(startWordIndex).join('');
-
-            speechSynthesisUtterance = new SpeechSynthesisUtterance(selectedText);
-
-            const selectedVoiceIndex = parseInt(voicesDropdown.value, 10);
-            if (!isNaN(selectedVoiceIndex) && voices[selectedVoiceIndex]) {
-                speechSynthesisUtterance.voice = voices[selectedVoiceIndex];
-            }
-
-            speechSynthesisUtterance.rate = parseFloat(rateControl.value);
-            speechSynthesisUtterance.pitch = 1;
-
-            const totalWords = words.length;
-
-            readingStartTime = Date.now();
-
-            speechSynthesisUtterance.onboundary = (event) => {
-                const charIndex = event.charIndex;
-                let cumulativeCharCount = 0;
-
-                for (let i = startWordIndex; i < cachedSpans.length; i++) {
-                    cumulativeCharCount += cachedSpans[i].textContent.length;
-                    if (cumulativeCharCount > charIndex) {
-                        highlightWord(i);
-                        updateProgress(i, totalWords);
-                        break;
-                    }
-                }
-            };
-
-            speechSynthesisUtterance.onend = () => {
-                cachedSpans.forEach(span => span.classList.remove('highlight'));
-                resetProgress();
-            };
-
-            speechSynthesis.speak(speechSynthesisUtterance);
-        }
-
-        function updateRate(rate) {
-            rateValue.textContent = rate;
-        }
-
-        function resetProgress() {
-            progressPercent.textContent = '0%';
-            timeElapsed.textContent = '00:00:00';
-            timeRemaining.textContent = '00:00:00';
-        }
-
-        function pauseReading() {
-            if (speechSynthesis.speaking) {
-                speechSynthesis.pause();
-            }
-        }
-
-        function resumeReading() {
-            if (speechSynthesis.paused) {
-                speechSynthesis.resume();
-            }
-        }
-
-        function stopReading() {
-            if (speechSynthesis.speaking) {
-                speechSynthesis.cancel();
-                cachedSpans.forEach(span => span.classList.remove('highlight'));
-                resetProgress();
-            }
-        }
-
-        function populateVoices() {
-            function retryPopulateVoices(attempt = 0) {
-                if (!('speechSynthesis' in window)) {
-                    alert('Text-to-speech is not supported in your browser. Please try a different browser.');
-                    return;
-                }
-                voices = speechSynthesis.getVoices();
-                if (voices.length === 0 && attempt < 5) {
-                    setTimeout(() => retryPopulateVoices(attempt + 1), 200 * Math.pow(2, attempt));
-                } else if (voices.length === 0) {
-                    console.error("Failed to load voices after multiple attempts.");
-                } else {
-                    filterVoicesByLanguage();
-                }
-            }
-            retryPopulateVoices();
-        }
-
-        textInput.addEventListener('input', updateTextDisplay);
-        speechSynthesis.addEventListener('voiceschanged', populateVoices);
-        populateVoices();
-
-    </script>
-
-    <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Please update your bookmark to /app.</div>
 </footer>
 </body>
 </html>

--- a/voices.html
+++ b/voices.html
@@ -9,31 +9,30 @@
     gtag('js', new Date());
     gtag('config', 'G-SVGML1VGPG');
   </script>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
   <meta charset="utf-8">
   <title>Voice Gallery | System Voices and How to Add More</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="description" content="Learn why Read‑Aloud voice lists differ by browser, how to install additional system voices on iOS, macOS, Windows, and Android, and how to fix missing voices." />
-  <link rel="canonical" href="https://www.read-aloud.com/voices.html">
-  <link rel="stylesheet" href="site.css">
+  <link rel="canonical" href="https://read-aloud.com/voices.html">
+  <link rel="stylesheet" href="/site.css">
 </head>
 <body>
 <header>
   <div class="navbar">
     <div class="logo">Read‑Aloud</div>
     <nav class="nav-links" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="app.html">Tool</a>
-      <a href="guides.html">Guides</a>
-      <a href="help.html">Help</a>
-      <a href="voices.html" aria-current="page">Voices</a>
-      <a href="about.html">About</a>
+      <a href="/index.html">Home</a>
+      <a href="/app.html">Tool</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/help.html">Help</a>
+      <a href="/voices.html" aria-current="page">Voices</a>
+      <a href="/about.html">About</a>
     </nav>
   </div>
 </header>
 
 <main>
-  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Voices</div>
+  <div class="breadcrumb"><a href="/index.html">Home</a> <span aria-hidden="true">›</span> Voices</div>
   <h1>Voice Gallery</h1>
   <p class="lead">Read‑Aloud lists the text-to-speech voices already installed on your device. Here is why lists differ by browser and how to add more voices on every major platform.</p>
 
@@ -109,7 +108,7 @@
       </ul>
       <p>
         Still stuck? Send your device model, OS version, browser version, and a screenshot of the empty
-        dropdown through the <a href="contact.html">Contact page</a>. We maintain a running list of
+        dropdown through the <a href="/contact.html">Contact page</a>. We maintain a running list of
         browser quirks and can suggest a specific pairing that works for your setup.
       </p>
     </div>
@@ -118,28 +117,28 @@
   <section class="related">
     <h3>Related guides</h3>
     <ul>
-      <li><a href="guides/tts-voice-selection.html">How to Choose the Best Voice</a></li>
-      <li><a href="guides/tts-for-students.html">Student listening workflow</a></li>
-      <li><a href="guides/tts-for-adhd-focus.html">Focus and pacing with timers</a></li>
-      <li><a href="guides/tts-privacy-safety.html">Privacy &amp; safety habits</a></li>
+      <li><a href="/guides/tts-voice-selection.html">How to Choose the Best Voice</a></li>
+      <li><a href="/guides/tts-for-students.html">Student listening workflow</a></li>
+      <li><a href="/guides/tts-for-adhd-focus.html">Focus and pacing with timers</a></li>
+      <li><a href="/guides/tts-privacy-safety.html">Privacy &amp; safety habits</a></li>
     </ul>
   </section>
 </main>
 
 <footer>
   <div>
-    <a href="index.html">Home</a>
-    <a href="app.html">Tool</a>
-    <a href="guides.html">Guides</a>
-    <a href="help.html">Help</a>
-    <a href="voices.html" aria-current="page">Voices</a>
-    <a href="about.html">About</a>
-    <a href="contact.html">Contact</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
+    <a href="/index.html">Home</a>
+    <a href="/app.html">Tool</a>
+    <a href="/guides.html">Guides</a>
+    <a href="/help.html">Help</a>
+    <a href="/voices.html" aria-current="page">Voices</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
     <a href="privacy.html#controls">Privacy settings</a>
-    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
-    <a href="sitemap.xml">Sitemap</a>
+    <a href="/recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="/sitemap.xml">Sitemap</a>
   </div>
   <div class="legal">© 2025 Read‑Aloud. Voice availability depends on your operating system and browser.</div>
 </footer>

--- a/voices.html
+++ b/voices.html
@@ -1,115 +1,147 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
-<meta charset="utf-8">
-<title>Voice Gallery | Read-Aloud</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="description" content="Sample the most popular browser voices before you read text aloud. Click any button to hear a 5-second demo.">
-<style>
-body{margin:0;font:16px/1.5 Arial,Helvetica,sans-serif;background:#f9f9ff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
-main{max-width:900px;margin:auto;padding:20px}
-h1{margin-top:0;text-align:center}
-.small{font-size:0.9em;color:#e0e0e0}
-.grid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
-.voice card{background:#fff;border:1px solid #ddd;border-radius:6px;padding:12px}
-button.demo{width:100%;padding:10px;background:#ff0;border:2px solid #777;cursor:pointer;font:15px/1.2 Tahoma;color:#000}
-.ads{margin:28px 0;text-align:center}
-</style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SVGML1VGPG');
+  </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <meta charset="utf-8">
+  <title>Voice Gallery | System Voices and How to Add More</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Learn why Read‑Aloud voice lists differ by browser, how to install additional system voices on iOS, macOS, Windows, and Android, and how to fix missing voices." />
+  <link rel="canonical" href="https://www.read-aloud.com/voices.html">
+  <link rel="stylesheet" href="site.css">
 </head>
-
 <body>
 <header>
-  <nav id="mainNav">
-    <a href="index.html">Home</a>
-    <a href="voices.html" aria-current="page">Voices</a>
-    <a href="help.html">Help</a>
-    <a href="guides.html">Guides</a>
-    <a href="recommendations.html">Recommendations</a>
-    <a href="about.html">About</a>
-    <a href="privacy.html">Privacy</a>
-    <a href="terms.html">Terms</a>
-  </nav>
+  <div class="navbar">
+    <div class="logo">Read‑Aloud</div>
+    <nav class="nav-links" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="app.html">Tool</a>
+      <a href="guides.html">Guides</a>
+      <a href="help.html">Help</a>
+      <a href="voices.html" aria-current="page">Voices</a>
+      <a href="about.html">About</a>
+    </nav>
+  </div>
 </header>
 
 <main>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span aria-hidden="true">›</span> Voices</div>
   <h1>Voice Gallery</h1>
-  <p>Preview eleven of the most widely-installed system voices.  
-     Click a button to hear the classic pangram <em>“The quick brown fox jumps over the lazy dog.”</em>  
-     All audio is generated locally in your browser—nothing is uploaded.</p>
+  <p class="lead">Read‑Aloud lists the text-to-speech voices already installed on your device. Here is why lists differ by browser and how to add more voices on every major platform.</p>
 
-  <section class="grid" id="voiceGrid"></section>
+  <section>
+    <h2>Why voice lists look different</h2>
+    <div class="card">
+      <p>
+        Read‑Aloud uses the Speech Synthesis API built into your browser. That API surfaces the voices
+        shipped with your operating system plus any optional packs you have installed. macOS and iOS
+        often ship with several natural voices, while some Windows builds include only a handful until
+        you add language packs. ChromeOS and many Android devices rely on Google’s system TTS engine,
+        which exposes different options depending on region and device manufacturer.
+      </p>
+      <p>
+        The browser also matters. Chrome and Edge often expose the newest voices first, while Firefox
+        may list fewer voices on some platforms. If you switch browsers and see additional options,
+        that is expected: each browser filters the system catalog differently. Regardless of the list,
+        all playback happens locally—the tool does not stream your text to a cloud engine.
+      </p>
+    </div>
+  </section>
 
-  <div class="ads">
-    <!-- 728×90 display ad -->
-    <ins class="adsbygoogle"
-         style="display:inline-block;width:728px;height:90px"
-         data-ad-client="ca-pub-4003447295960802"
-         data-ad-slot="YOUR_SLOT_ID"></ins>
-    <script async
-      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-    <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
-  </div>
+  <section>
+    <h2>How to install or enable voices</h2>
+    <div class="grid two-col">
+      <div class="card">
+        <h3>iOS and iPadOS</h3>
+        <ul>
+          <li>Open <em>Settings → Accessibility → Spoken Content</em> and tap <strong>Voices</strong>.</li>
+          <li>Select a language, then download an enhanced voice such as “Siri Voice 4.” Enhanced voices sound more natural but may take longer to download.</li>
+          <li>Return to Read‑Aloud and reload the page. The new voice should appear in the list after the download finishes.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>macOS</h3>
+        <ul>
+          <li>Open <em>System Settings → Accessibility → Spoken Content</em> and choose <strong>System Voice → Manage Voices</strong>.</li>
+          <li>Add the languages and specific voices you want, then allow downloads to complete.</li>
+          <li>Restart the browser to refresh the Speech Synthesis catalog.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Windows 10/11</h3>
+        <ul>
+          <li>Open <em>Settings → Time &amp; Language → Speech</em> and review the <strong>Manage voices</strong> section.</li>
+          <li>Use <strong>Add voices</strong> to install language packs that include TTS voices. Choose voices that match the language you paste most often.</li>
+          <li>Restart the browser; Edge and Chrome tend to expose new voices immediately after a reboot.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Android</h3>
+        <ul>
+          <li>Open <em>Settings → System → Languages &amp; input → Text-to-speech output</em>.</li>
+          <li>Select <strong>Preferred engine</strong> (often Google’s engine) and tap the gear icon to manage installed voices.</li>
+          <li>Download offline voice data for the languages you use. Some manufacturers hide voices under “Offline speech recognition.”</li>
+          <li>Reopen Read‑Aloud in Chrome. If the voice list is still short, try enabling “Use network voices” in the same settings panel.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
 
-  <h2 id="how">How this helps you</h2>
-  <ul>
-    <li><strong>Dyslexia &amp; ADHD-friendly&nbsp;reading</strong> – pick a pace and accent that keeps you engaged.</li>
-    <li><strong>Language practice</strong> – try Spanish or French voices to reinforce pronunciation.</li>
-    <li><strong>Voice-over work</strong> –sample multiple tones before recording audio.</li>
-  </ul>
+  <section>
+    <h2>What to do if voices are missing</h2>
+    <div class="card">
+      <p>
+        If the list still looks sparse after installing voices, try these quick fixes:
+      </p>
+      <ul>
+        <li>Close and reopen the browser. Some platforms only refresh the list on launch.</li>
+        <li>Disable battery saver or low-power modes that might pause voice downloads mid-way.</li>
+        <li>On desktop, open a private window to rule out extensions blocking the Speech Synthesis API.</li>
+        <li>Ensure your system language settings match the voice language you want; mismatched locales sometimes hide voices.</li>
+      </ul>
+      <p>
+        Still stuck? Send your device model, OS version, browser version, and a screenshot of the empty
+        dropdown through the <a href="contact.html">Contact page</a>. We maintain a running list of
+        browser quirks and can suggest a specific pairing that works for your setup.
+      </p>
+    </div>
+  </section>
+
+  <section class="related">
+    <h3>Related guides</h3>
+    <ul>
+      <li><a href="guides/tts-voice-selection.html">How to Choose the Best Voice</a></li>
+      <li><a href="guides/tts-for-students.html">Student listening workflow</a></li>
+      <li><a href="guides/tts-for-adhd-focus.html">Focus and pacing with timers</a></li>
+      <li><a href="guides/tts-privacy-safety.html">Privacy &amp; safety habits</a></li>
+    </ul>
+  </section>
 </main>
 
 <footer>
-  © 2025 Read‑Aloud · <a href="contact.html">Contact</a> · <a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a><br>
-  <strong>As an Amazon Associate I earn from qualifying purchases.</strong>
+  <div>
+    <a href="index.html">Home</a>
+    <a href="app.html">Tool</a>
+    <a href="guides.html">Guides</a>
+    <a href="help.html">Help</a>
+    <a href="voices.html" aria-current="page">Voices</a>
+    <a href="about.html">About</a>
+    <a href="contact.html">Contact</a>
+    <a href="privacy.html">Privacy</a>
+    <a href="terms.html">Terms</a>
+    <a href="privacy.html#controls">Privacy settings</a>
+    <a href="recommendations.html" rel="sponsored nofollow">Recommendations</a>
+    <a href="sitemap.xml">Sitemap</a>
+  </div>
+  <div class="legal">© 2025 Read‑Aloud. Voice availability depends on your operating system and browser.</div>
 </footer>
-
-<script>
-/* ------- build demo buttons ------- */
-const voicesWanted = [
-  {lang:'en-US', label:'English US – Female'},
-  {lang:'en-US', label:'English US – Male'},
-  {lang:'en-GB', label:'English UK – Female'},
-  {lang:'en-GB', label:'English UK – Male'},
-  {lang:'es-ES', label:'Español – Femenino'},
-  {lang:'es-ES', label:'Español – Masculino'},
-  {lang:'fr-FR', label:'Français – Féminin'},
-  {lang:'fr-FR', label:'Français – Masculin'},
-  {lang:'de-DE', label:'Deutsch – Weiblich'},
-  {lang:'de-DE', label:'Deutsch – Männlich'},
-  {lang:'it-IT', label:'Italiano – Femmina'}
-];
-
-function populate() {
-  const all = speechSynthesis.getVoices();
-  const grid = document.getElementById('voiceGrid');
-  grid.innerHTML = '';
-  voicesWanted.forEach(w=>{
-    const v = all.find(x=>x.lang===w.lang && x.name.toLowerCase().includes('female')===w.label.includes('Female') && x.name.toLowerCase().includes('male')===w.label.includes('Male')) || all.find(x=>x.lang===w.lang);
-    const card = document.createElement('div');
-    card.className='voice card';
-    card.innerHTML = `<p>${w.label}</p><button class="demo">Play demo</button>`;
-    card.querySelector('button').onclick = ()=>{
-      const u = new SpeechSynthesisUtterance('The quick brown fox jumps over the lazy dog.');
-      if (v) u.voice = v;
-      speechSynthesis.speak(u);
-    };
-    grid.appendChild(card);
-  });
-}
-if (speechSynthesis.getVoices().length) populate();
-else speechSynthesis.onvoiceschanged = populate;
-</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore the Google Analytics tag on the Study use case page so tracking remains consistent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956889e27488331b9c8a596c1f14b72)