### PR TITLE
Unify site styling and add cookie consent gating

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,50 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>About | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/about.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Read‑Aloud is a free, privacy‑first text‑to‑speech tool that reads your text out loud in your browser using your device’s voices.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-  main{max-width:980px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-  .highlight{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-  ul{padding-left:20px}
-  hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -128,8 +106,10 @@
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -7,8 +7,29 @@
   <link rel="canonical" href="https://read-aloud.com/blog/">
   <title>Blog | Read‑Aloud</title>
   <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/" aria-current="page">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
+</header>
+
   <p>Redirecting to <a href="/blog/">/blog/</a>…</p>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
+</footer>
 </body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,56 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Blog &amp; Updates | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/blog/">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Articles and updates written for people who use read‑aloud.com: privacy, voices, troubleshooting, study workflows, and what’s new.">
 
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:980px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-  .grid{display:grid;grid-template-columns:1fr;gap:14px;margin-top:14px}
-  @media (min-width:900px){.grid{grid-template-columns:1.2fr 0.8fr}}
-  .card{background:#fff;border:1px solid #ddd;border-radius:12px;padding:14px}
-  .card h2,.card h3{margin:0 0 10px 0}
-  .meta{color:#555;font-size:0.95em;margin:6px 0 0 0}
-  .tag{display:inline-block;background:#eef7ff;border:1px solid #b8d8ff;color:#003a66;
-       padding:2px 8px;border-radius:999px;font-size:12px;margin-right:6px}
-  ul{padding-left:20px}
-  hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/" aria-current="page">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -107,8 +80,10 @@
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1,46 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Contact | Read-Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/contact.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Contact the Read-Aloud team for support or feedback.">
-<style>
-body{margin:0;font:16px/1.6 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:720px;margin:auto;padding:26px}
-label{display:block;margin:12px 0 4px}
-input,textarea{width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;font-size:15px;box-sizing:border-box}
-button{margin-top:12px;padding:10px 18px;background:#ff0;border:2px solid #777;font:15px/1.2 Tahoma;cursor:pointer;color:#000}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -65,8 +47,10 @@ button{margin-top:12px;padding:10px 18px;background:#ff0;border:2px solid #777;f
   </form>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/cookie-consent.js
+++ b/cookie-consent.js
@@ -1,0 +1,119 @@
+(() => {
+  const CONSENT_KEY = 'ra_cookie_consent';
+  const ACCEPTED = 'accepted';
+  const REJECTED = 'rejected';
+  const GA_ID = 'G-SVGML1VGPG';
+
+  const loadScript = (src, attrs = {}) => {
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = src;
+    Object.entries(attrs).forEach(([key, value]) => {
+      if (value !== undefined) {
+        script.setAttribute(key, value);
+      }
+    });
+    document.head.appendChild(script);
+    return script;
+  };
+
+  const initAnalytics = () => {
+    if (window.__raAnalyticsLoaded) return;
+    window.__raAnalyticsLoaded = true;
+    loadScript(`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`);
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){window.dataLayer.push(arguments);}
+    window.gtag = window.gtag || gtag;
+    window.gtag('js', new Date());
+    window.gtag('config', GA_ID);
+  };
+
+  const initAdsense = () => {
+    const slot = document.getElementById('adsense-slot');
+    if (!slot || window.__raAdsenseLoaded) return;
+    window.__raAdsenseLoaded = true;
+    const adClient = slot.dataset.adClient;
+    const adSlot = slot.dataset.adSlot;
+    if (!adClient || !adSlot) return;
+
+    loadScript(`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adClient}`, {
+      crossorigin: 'anonymous',
+    });
+
+    slot.textContent = '';
+    const ins = document.createElement('ins');
+    ins.className = 'adsbygoogle';
+    ins.style.display = 'inline-block';
+    if (slot.dataset.adWidth && slot.dataset.adHeight) {
+      ins.style.width = `${slot.dataset.adWidth}px`;
+      ins.style.height = `${slot.dataset.adHeight}px`;
+    }
+    ins.dataset.adClient = adClient;
+    ins.dataset.adSlot = adSlot;
+    slot.appendChild(ins);
+    (window.adsbygoogle = window.adsbygoogle || []).push({});
+  };
+
+  const applyConsent = (value) => {
+    if (value === ACCEPTED) {
+      initAnalytics();
+      initAdsense();
+    }
+  };
+
+  const buildBanner = () => {
+    const banner = document.createElement('div');
+    banner.className = 'cookie-banner';
+    banner.setAttribute('role', 'dialog');
+    banner.setAttribute('aria-live', 'polite');
+    banner.innerHTML = `
+      <div>
+        <strong>Privacy settings</strong>
+        <p>We only load analytics and ads if you accept. You can update your choice anytime in <a href="/privacy.html">Privacy</a>.</p>
+      </div>
+      <div class="cookie-banner__actions">
+        <button type="button" class="secondary" data-consent="reject">Reject</button>
+        <button type="button" data-consent="accept">Accept</button>
+      </div>
+    `;
+    banner.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-consent]');
+      if (!button) return;
+      const choice = button.dataset.consent === 'accept' ? ACCEPTED : REJECTED;
+      localStorage.setItem(CONSENT_KEY, choice);
+      banner.remove();
+      applyConsent(choice);
+    });
+    return banner;
+  };
+
+  const showBanner = () => {
+    if (document.querySelector('.cookie-banner')) return;
+    document.body.appendChild(buildBanner());
+  };
+
+  const setupReset = () => {
+    document.querySelectorAll('[data-cookie-reset]').forEach((button) => {
+      button.addEventListener('click', () => {
+        localStorage.removeItem(CONSENT_KEY);
+        showBanner();
+      });
+    });
+  };
+
+  const init = () => {
+    const stored = localStorage.getItem(CONSENT_KEY);
+    if (!stored) {
+      showBanner();
+    } else {
+      applyConsent(stored);
+    }
+    setupReset();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/guide-adhd-focus-routines.html
+++ b/guide-adhd-focus-routines.html
@@ -1,45 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-SVGML1VGPG');
-</script>
 <meta charset="utf-8">
 <title>ADHD-Friendly Focus Routines With Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-adhd-focus-routines.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Non-medical focus routines for listening with ADHD using Read‑Aloud: environment, pacing, common mistakes, workflows, and FAQs.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:960px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .box{background:#f7f9ff;border:1px solid #c7d8ff;border-radius:10px;padding:12px;margin:16px 0}
-  ul{padding-left:20px}
-  ol{padding-left:22px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 <main>
   <h1>ADHD-Friendly Focus Routines With Read‑Aloud</h1>
@@ -113,8 +95,10 @@
     Keep experimenting: the <a href="/guides.html">guides hub</a> lists more routines. Pair these habits with the <a href="/guide-language-shadowing.html">language shadowing guide</a> for repetition practice or the <a href="/guide-reading-long-documents.html">long documents guide</a> for structured study blocks.
   </p>
 </main>
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-best-voice-speed.html
+++ b/guide-best-voice-speed.html
@@ -1,45 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-SVGML1VGPG');
-</script>
 <meta charset="utf-8">
 <title>Choose the Best Voice and Speed | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-best-voice-speed.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Learn how to choose voices and speech rates in Read‑Aloud for better comprehension, focus, and proofing. Includes common mistakes, workflows, and FAQs.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:960px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .tip{background:#f7f9ff;border:1px solid #c7d8ff;border-radius:10px;padding:12px;margin:16px 0}
-  ul{padding-left:20px}
-  ol{padding-left:22px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 <main>
   <h1>Choosing the Best Voice and Speed</h1>
@@ -105,8 +87,10 @@
     Next steps: explore more scenarios on the <a href="/guides.html">guides page</a>, skim the <a href="/help.html">Help</a> troubleshooting notes, or combine pacing changes with the <a href="/guide-keyboard-shortcuts.html">keyboard shortcuts guide</a> to work faster.
   </p>
 </main>
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-browser-compatibility.html
+++ b/guide-browser-compatibility.html
@@ -1,53 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Browser Compatibility & Voice Availability | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-browser-compatibility.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="A practical compatibility guide for read-aloud.com: why voice lists differ across browsers, what works best on desktop and mobile, and how to fix 'no voices' or 'no sound'.">
-<style>
-body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-header a:hover,footer a:hover{text-decoration:underline}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:980px;margin:auto;padding:24px}
-h1{margin-top:0}
-.small{color:#444;font-size:0.95em}
-.box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-.specific{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-table{width:100%;border-collapse:collapse;margin:12px 0}
-th,td{border:1px solid #ddd;padding:10px;vertical-align:top}
-th{background:#f2f2f2}
-ul{padding-left:20px}
-hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -181,8 +156,10 @@ hr{margin:24px 0}
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-dyslexia-adhd.html
+++ b/guide-dyslexia-adhd.html
@@ -1,49 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Text‑to‑Speech for Dyslexia & ADHD | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-dyslexia-adhd.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Practical ways to use text-to-speech for dyslexia and ADHD: pacing, dual reading, chunking, focus strategies, and fatigue reduction.">
-<style>
-body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-header a:hover,footer a:hover{text-decoration:underline}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0}
-.box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-ul{padding-left:20px}
-.small{color:#444;font-size:0.95em}
-hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -138,8 +117,10 @@ hr{margin:24px 0}
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-dyslexia-dual-reading.html
+++ b/guide-dyslexia-dual-reading.html
@@ -1,45 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-SVGML1VGPG');
-</script>
 <meta charset="utf-8">
 <title>Dual Reading Strategies for Dyslexia | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-dyslexia-dual-reading.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Dual reading routines for dyslexia: combine listening and visual pacing with Read‑Aloud. Includes common mistakes, workflows, and FAQs.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:960px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .callout{background:#fef6f6;border:1px solid #f2c7c7;border-radius:10px;padding:12px;margin:16px 0}
-  ul{padding-left:20px}
-  ol{padding-left:22px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 <main>
   <h1>Dual Reading Strategies for Dyslexia</h1>
@@ -114,8 +96,10 @@
     Keep iterating. Combine these steps with the <a href="/guide-adhd-focus-routines.html">focus routines</a> for attention support or the <a href="/guide-study-pomodoro.html">Pomodoro guide</a> to structure your study blocks.
   </p>
 </main>
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-how-to-use.html
+++ b/guide-how-to-use.html
@@ -1,53 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>How to Use Read‑Aloud (Step‑by‑Step) | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-how-to-use.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Step-by-step instructions for using Read‑Aloud: paste text, choose a voice, adjust speed, use shortcuts, and troubleshoot common issues.">
-<style>
-body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-header a:hover,footer a:hover{text-decoration:underline}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0}
-.small{color:#444;font-size:0.95em}
-.box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-.specific{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-.template{background:#eef7ff;border:1px solid #b8d8ff;padding:12px;border-radius:10px;overflow:auto}
-ul{padding-left:20px}
-hr{margin:24px 0}
-code,kbd{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace}
-kbd{border:1px solid #bbb;border-bottom:2px solid #999;border-radius:6px;padding:2px 6px;background:#fff}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -123,8 +98,10 @@ Question: does it pause correctly after commas, periods, and question marks?</pr
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-keyboard-shortcuts.html
+++ b/guide-keyboard-shortcuts.html
@@ -1,46 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-SVGML1VGPG');
-</script>
 <meta charset="utf-8">
 <title>Keyboard Shortcuts for Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-keyboard-shortcuts.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Work faster in Read‑Aloud using keyboard shortcuts. Learn platform tips, common mistakes, example workflows, and FAQs.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:960px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .tip{background:#f7f9ff;border:1px solid #c7d8ff;border-radius:10px;padding:12px;margin:16px 0}
-  ul{padding-left:20px}
-  ol{padding-left:22px}
-  code{background:#f4f4f4;padding:2px 4px;border-radius:4px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 <main>
   <h1>Keyboard Shortcuts for Read‑Aloud</h1>
@@ -124,8 +105,10 @@
     Keep practicing. Combine shortcuts with the <a href="/guide-study-pomodoro.html">study routine</a> and <a href="/guide-proofreading-checklist.html">proofreading checklist</a> to move faster without sacrificing quality.
   </p>
 </main>
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-language-learning.html
+++ b/guide-language-learning.html
@@ -1,51 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Language Learning with Text‑to‑Speech | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-language-learning.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Use text-to-speech for pronunciation practice, shadowing, and language routines. A practical guide for learners.">
-<style>
-body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-header a:hover,footer a:hover{text-decoration:underline}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0}
-.tip{background:#eef7ff;border:1px solid #b8d8ff;padding:12px;border-radius:10px}
-.specific{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-.template{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px;overflow:auto}
-ul{padding-left:20px}
-.small{color:#444;font-size:0.95em}
-hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -155,8 +132,10 @@ FRANÇAIS (French)
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-language-shadowing.html
+++ b/guide-language-shadowing.html
@@ -1,45 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-SVGML1VGPG');
-</script>
 <meta charset="utf-8">
 <title>Language Shadowing With Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-language-shadowing.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Shadowing practice with Read‑Aloud: pick voices, build repetition drills, avoid common mistakes, and follow example workflows with FAQs.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:960px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .tip{background:#f5fbff;border:1px solid #c5e2ff;border-radius:10px;padding:12px;margin:16px 0}
-  ul{padding-left:20px}
-  ol{padding-left:22px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 <main>
   <h1>Language Shadowing With Read‑Aloud</h1>
@@ -113,8 +95,10 @@
     Explore more techniques in the <a href="/guides.html">guides hub</a>. Pair shadowing with the <a href="/guide-language-learning.html">language learning guide</a>, use the <a href="/guide-best-voice-speed.html">voice tuning guide</a> for clarity, and consult <a href="/help.html">Help</a> if playback stalls.
   </p>
 </main>
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-listen-to-pdfs.html
+++ b/guide-listen-to-pdfs.html
@@ -1,45 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-SVGML1VGPG');
-</script>
 <meta charset="utf-8">
 <title>How to Listen to PDFs With Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-listen-to-pdfs.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Turn PDFs into listenable text with Read‑Aloud. Learn extraction, chunking, and pacing strategies plus FAQs for long academic PDFs.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:960px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .callout{background:#f6fff5;border:1px solid #c5e7c1;border-radius:10px;padding:12px;margin:16px 0}
-  ul{padding-left:20px}
-  ol{padding-left:22px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 <main>
   <h1>How to Listen to PDFs With Read‑Aloud</h1>
@@ -106,8 +88,10 @@
     Keep exploring the <a href="/guides.html">guides hub</a> for more workflows. Pair PDF listening with the <a href="/guide-study-pomodoro.html">study Pomodoro routine</a> or the <a href="/guide-adhd-focus-routines.html">focus routines</a> guide to stay engaged, and visit the <a href="/help.html">Help</a> page if playback stalls.
   </p>
 </main>
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-local-vs-cloud-tts.html
+++ b/guide-local-vs-cloud-tts.html
@@ -1,51 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Local vs Cloud Text‑to‑Speech | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-local-vs-cloud-tts.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="A decision guide to local vs cloud text-to-speech: privacy tradeoffs, voice quality, safety checklist, and what to consider before you paste sensitive text.">
-<style>
-body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-header a:hover,footer a:hover{text-decoration:underline}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0}
-.box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-.specific{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-.template{background:#eef7ff;border:1px solid #b8d8ff;padding:12px;border-radius:10px;overflow:auto}
-ul{padding-left:20px}
-.small{color:#444;font-size:0.95em}
-hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -191,8 +168,10 @@ hr{margin:24px 0}
   </ul>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-offline-use.html
+++ b/guide-offline-use.html
@@ -1,45 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-SVGML1VGPG');
-</script>
 <meta charset="utf-8">
 <title>Offline and Low-Connection Use | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-offline-use.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Use Read‑Aloud offline or on weak connections. Learn what works locally, common mistakes, troubleshooting workflows, and FAQs.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:960px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .note{background:#f7f9ff;border:1px solid #c7d8ff;border-radius:10px;padding:12px;margin:16px 0}
-  ul{padding-left:20px}
-  ol{padding-left:22px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 <main>
   <h1>Offline and Low-Connection Use</h1>
@@ -120,8 +102,10 @@
     Keep exploring the <a href="/guides.html">guides hub</a> for more workflows, and visit <a href="/guide-best-voice-speed.html">voice tuning</a> if your offline voice sounds different from your usual pick.
   </p>
 </main>
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-privacy.html
+++ b/guide-privacy.html
@@ -1,51 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Privacy‑First Text‑to‑Speech | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-privacy.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="A plain-English explanation of privacy-first text-to-speech: local browser voices vs cloud voices, and how to make privacy-friendly choices.">
-<style>
-body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-header a:hover,footer a:hover{text-decoration:underline}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0}
-.box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-.specific{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-.template{background:#eef7ff;border:1px solid #b8d8ff;padding:12px;border-radius:10px;overflow:auto}
-ul{padding-left:20px}
-.small{color:#444;font-size:0.95em}
-hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -124,8 +101,10 @@ hr{margin:24px 0}
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-proofread.html
+++ b/guide-proofread.html
@@ -1,51 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Proofread by Ear (Text‑to‑Speech Editing) | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-proofread.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Use text-to-speech to proofread essays, emails, and reports. Catch missing words, awkward phrasing, and typos faster.">
-<style>
-body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-header a:hover,footer a:hover{text-decoration:underline}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0}
-.box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-.specific{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-.template{background:#eef7ff;border:1px solid #b8d8ff;padding:12px;border-radius:10px;overflow:auto}
-ul{padding-left:20px}
-.small{color:#444;font-size:0.95em}
-hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -153,8 +130,10 @@ hr{margin:24px 0}
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-proofreading-checklist.html
+++ b/guide-proofreading-checklist.html
@@ -1,45 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-SVGML1VGPG');
-</script>
 <meta charset="utf-8">
 <title>Proofreading by Ear Checklist | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-proofreading-checklist.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="A detailed proofreading-by-ear checklist using Read‑Aloud. Catch missing words, confusing pacing, and style issues with example workflows and FAQs.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:960px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .tip{background:#eef7ff;border:1px solid #cde1ff;border-radius:10px;padding:12px;margin:16px 0}
-  ul{padding-left:20px}
-  ol{padding-left:22px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 <main>
   <h1>Proofreading by Ear Checklist</h1>
@@ -108,8 +90,10 @@
     Keep improving your editing routine in the <a href="/guides.html">guides hub</a>. Pair this checklist with the broader <a href="/guide-proofread.html">proofreading guide</a> or combine with the <a href="/guide-study-pomodoro.html">Pomodoro workflow</a> to prevent fatigue during revisions.
   </p>
 </main>
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-reading-long-documents.html
+++ b/guide-reading-long-documents.html
@@ -1,45 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-SVGML1VGPG');
-</script>
 <meta charset="utf-8">
 <title>Reading Long Documents With Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-reading-long-documents.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Strategies for listening to long articles, research papers, and manuals with Read‑Aloud, including chunking, pacing, and focus tips.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:960px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .box{background:#f7f9ff;border:1px solid #c7d8ff;border-radius:10px;padding:12px;margin:16px 0}
-  ul{padding-left:20px}
-  ol{padding-left:22px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 <main>
   <h1>Reading Long Documents With Read‑Aloud</h1>
@@ -110,8 +92,10 @@
     Keep exploring: the <a href="/guides.html">guides hub</a> collects more workflows. If you want to fine‑tune attention, read the <a href="/guide-adhd-focus-routines.html">focus routines guide</a> and combine it with the <a href="/guide-language-shadowing.html">language shadowing</a> approach for paced repetition.
   </p>
 </main>
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-study-pomodoro.html
+++ b/guide-study-pomodoro.html
@@ -1,45 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-SVGML1VGPG');
-</script>
 <meta charset="utf-8">
 <title>Study With Pomodoro and Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-study-pomodoro.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Combine Pomodoro timers with Read‑Aloud to study efficiently. Learn pacing, breaks, common mistakes, and FAQs.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:960px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .callout{background:#fff7d6;border:1px solid #f0d36b;border-radius:10px;padding:12px;margin:16px 0}
-  ul{padding-left:20px}
-  ol{padding-left:22px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 <main>
   <h1>Study With Pomodoro and Read‑Aloud</h1>
@@ -111,8 +93,10 @@
     Continue refining your workflow in the <a href="/guides.html">guides hub</a> and check <a href="/help.html">Help</a> if playback pauses. For precision editing, pair Pomodoro with the <a href="/guide-proofreading-checklist.html">proofreading checklist</a> so each sprint has a clear quality goal.
   </p>
 </main>
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guide-study.html
+++ b/guide-study.html
@@ -1,51 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Study With Text‑to‑Speech | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/guide-study.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="A practical study workflow using text-to-speech: turning readings into audio-supported sessions, improving retention, and reducing fatigue.">
-<style>
-body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-header a:hover,footer a:hover{text-decoration:underline}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0}
-.callout{background:#eef7ff;border:1px solid #b8d8ff;padding:12px;border-radius:10px}
-.specific{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-.template{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px;overflow:auto}
-ul{padding-left:20px}
-.small{color:#444;font-size:0.95em}
-hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -168,8 +145,10 @@ Next step (choose one):
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/guides.html
+++ b/guides.html
@@ -1,50 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Guides & Tutorials | Read‑Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Guides written specifically for read-aloud.com: studying, proofreading, dyslexia/ADHD support, language learning, privacy, and troubleshooting.">
 <link rel="canonical" href="https://read-aloud.com/guides.html">
-<style>
-body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-header a:hover,footer a:hover{text-decoration:underline}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0}
-.small{color:#444;font-size:0.95em}
-.card{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px;margin:12px 0}
-.specific{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-ul{padding-left:20px}
-hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html" aria-current="page">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -118,8 +96,10 @@ hr{margin:24px 0}
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/help.html
+++ b/help.html
@@ -1,46 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Help & FAQ | Read-Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Troubleshooting and frequently-asked questions for the free Read-Aloud text-to-speech tool.">
 <link rel="canonical" href="https://read-aloud.com/help.html">
-<style>
-body{margin:0;font:16px/1.6 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
-footer .small{color:#e0e0ff;font-size:0.9em;display:block;margin-top:4px}
-main{max-width:900px;margin:auto;padding:24px}
-h1{margin-top:0;font-size:1.9em}
-h2{margin-top:1.6em}
-dl dt{font-weight:700;margin-top:12px}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html" aria-current="page">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -76,8 +58,10 @@ dl dt{font-weight:700;margin-top:12px}
   </ul>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,16 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
@@ -19,73 +9,25 @@
 <meta name="description" content="Read-Aloud is a privacy-first browser text-to-speech tool. Paste text, pick a voice and speed, and listen instantly without downloading audio or uploading your content to a server.">
 
 <!-- ——— Retro CSS ——— -->
-<style>
-body{margin:0;background:#000080 url("bg_tile.gif") repeat;color:#fffc;font:14px Verdana}
-
-/* banner push */
-#top{background:#000040;border-bottom:3px double #ff0;text-align:center;padding:6px}
-#top h1{margin:4px 0;font:48px "Comic Sans MS";color:#0f0;text-shadow:2px 2px #f0f}
-
-/* nav */
-#mainNav{background:#002060;border-bottom:3px double #ff0;text-align:center;padding:6px}
-#mainNav a{color:#fff;text-decoration:none;margin:0 10px;font:15px/1.4 Verdana}
-#mainNav a:hover,#mainNav a:focus{text-decoration:underline}
-
-/* subtle support bar */
-#supportBar{position:relative;background:#00124a;border-bottom:2px solid #334;
-            font:13px Verdana;padding:3px 8px;color:#e0e0ff;
-            display:flex;justify-content:center;align-items:center;gap:10px}
-#supportBar .fill{position:absolute;top:0;left:0;height:100%;background:#ff0;opacity:.20}
-#supportBar .msg{position:relative;z-index:2;white-space:nowrap}
-.coffeeBtn{position:relative;z-index:2;color:#ff0;text-decoration:none;
-           border-bottom:1px dotted #ff0;padding:0 2px}
-.coffeeBtn:hover,.coffeeBtn:focus{background:#ff0;color:#000;border:none}
-@media(max-width:480px){#supportBar{gap:6px;flex-wrap:wrap;font-size:12px}}
-
-/* tool panel */
-.panel{margin:14px;background:#001a66;border:2px outset #ff0;padding:12px}
-textarea{width:100%;min-height:120px;padding:4px;border:3px inset #666;
-         font:15px/1.4 "Courier New";box-sizing:border-box}
-.btn{background:#ff0;border:2px outset #333;font:14px Tahoma;padding:6px 14px;color:#000;cursor:pointer}
-.highlight{background:#f0f;color:#000}
-progress{width:100%;height:12px;border:2px inset #333;background:#333}
-progress::-webkit-progress-value{background:#0f0}
-@media(max-width:640px){body{font-size:13px}}
-
-/* footer */
-footer{background:#002060;color:#fff;padding:8px 0;text-align:center;font:14px Verdana}
-footer a{color:#fff;text-decoration:none;margin:0 6px}
-footer a:hover{text-decoration:underline}
-footer .small{display:block;font-size:12px;color:#e0e0ff;margin-top:4px}
-
-.content h2,.content h3{color:#ff0;margin-top:0}
-.content a{color:#ff0}
-.content p, .content li{color:#f5f5ff}
-.content ul{padding-left:20px}
-.content section{margin-bottom:18px}
-.callout{background:#001f5c;border:1px solid #3355aa;padding:12px;border-radius:6px}
-</style>
-
-<!-- Google AdSense -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4003447295960802" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
 
 <!-- header -->
-<header>
-  <div id="top"><h1>Read-Aloud</h1></div>
-  <nav id="mainNav">
-    <a href="/index.html" aria-current="page">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html" aria-current="page">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <!-- support bar -->
@@ -96,6 +38,7 @@ footer .small{display:block;font-size:12px;color:#e0e0ff;margin-top:4px}
      class="coffeeBtn" aria-label="Buy me a coffee">☕ Buy me a coffee</a>
 </div>
 
+<main>
 <!-- main panel -->
 <div class="panel">
   <textarea id="txt" placeholder="Paste or type text here…"></textarea><br><br>
@@ -167,12 +110,11 @@ footer .small{display:block;font-size:12px;color:#e0e0ff;margin-top:4px}
   </ul>
 </div>
 
-<!-- Google 468×60 banner -->
-<div style="text-align:center;margin:14px">
-  <ins class="adsbygoogle" style="display:inline-block;width:468px;height:60px"
-       data-ad-client="ca-pub-4003447295960802" data-ad-slot="8374615023"></ins>
-  <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
+<div id="adsense-slot" class="ad-slot" data-ad-client="ca-pub-4003447295960802" data-ad-slot="8374615023" data-ad-width="468" data-ad-height="60">
+  Ads load after accepting cookies.
 </div>
+
+</main>
 
 <!-- meSpeak fallback -->
 <script src="https://cdn.jsdelivr.net/npm/mespeak@2.0.2/mespeak.min.js"></script>
@@ -202,8 +144,10 @@ function updateBar(visits){
 </script>
 
 <!-- footer -->
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,50 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Privacy Policy | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/privacy.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Privacy policy for Read‑Aloud (read-aloud.com). Read‑Aloud is a privacy-first text-to-speech tool that speaks text locally in your browser.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:980px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-  .highlight{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-  ul{padding-left:20px}
-  hr{margin:24px 0}
-  code{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -144,6 +122,14 @@
     <li>You can choose not to click promotional links or external links.</li>
   </ul>
 
+  <h2>Cookie preferences</h2>
+  <div class="box">
+    <p style="margin-top:0">
+      You can change your analytics and ads choice at any time. Selecting reset will show the consent banner again.
+    </p>
+    <button type="button" class="btn secondary" data-cookie-reset>Reset cookie preferences</button>
+  </div>
+
   <h2>7) Contact</h2>
   <p>
     If you have privacy questions, email <strong>admin@read-aloud.com</strong> or use the
@@ -165,8 +151,10 @@
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/recommendations.html
+++ b/recommendations.html
@@ -1,54 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Resources for Comfortable Listening | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/recommendations.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Non-commercial tips for making Read‑Aloud more comfortable: headset fit, quiet spaces, timers, note-taking routines, and internal guides to improve focus.">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:980px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  h2{margin-top:28px}
-  .small{color:#444;font-size:0.95em}
-  .box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-  .grid{display:grid;grid-template-columns:1fr;gap:14px}
-  @media (min-width:900px){.grid{grid-template-columns:1fr 1fr}}
-  .card{background:#fff;border:1px solid #ddd;border-radius:12px;padding:14px}
-  .card h3{margin:0 0 8px 0}
-  .card ul{margin:8px 0 0 0;padding-left:20px}
-  .muted{color:#555}
-  hr{margin:24px 0}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html" aria-current="page">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -138,8 +112,10 @@
   <p class="muted">Want more? Visit the <a href="/guides.html">Guides hub</a> for deep dives on focus routines, accessibility, and troubleshooting, or browse the <a href="/blog/">Blog</a> and <a href="/updates/">Updates</a>.</p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,309 +1,367 @@
-/* ======================
-   Global & General Styles
-   ====================== */
+:root {
+  color-scheme: light;
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --surface-muted: #f0f3f8;
+  --text: #1b1f2a;
+  --muted: #5a6475;
+  --primary: #1f5eff;
+  --primary-dark: #1442c8;
+  --border: #d8deea;
+  --highlight: #fff2c2;
+  --radius: 14px;
+  --shadow: 0 12px 30px rgba(25, 39, 62, 0.08);
+  --max-width: 1000px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 0;
-    background: linear-gradient(to bottom, #f8f9fa, #dee2e6);
-    color: #333;
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+}
+
+header.site-header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.nav-container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: var(--text);
+}
+
+.site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  align-items: center;
+}
+
+.site-nav a {
+  color: var(--muted);
+  font-weight: 600;
+  padding: 6px 10px;
+  border-radius: 999px;
+}
+
+.site-nav a[aria-current="page"] {
+  color: var(--primary);
+  background: rgba(31, 94, 255, 0.12);
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  color: var(--primary-dark);
+  text-decoration: none;
+  background: rgba(31, 94, 255, 0.08);
+}
+
+.site-footer {
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+}
+
+.footer-container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 20px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.footer-container a {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  line-height: 1.25;
+  color: var(--text);
+}
+
+h1 {
+  font-size: clamp(2rem, 2vw + 1.5rem, 2.75rem);
 }
 
 .small {
-    font-size: 0.9em;
-    color: #444;
+  font-size: 0.95rem;
+  color: var(--muted);
 }
 
-/* Container for centering content where needed */
-.container {
-    width: 90%;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 20px 0;
-    text-align: center;
+.card,
+.box,
+.panel,
+.callout,
+.tip,
+.specific,
+.highlight {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px;
+  box-shadow: var(--shadow);
 }
 
-/* ======================
-   Header
-   ====================== */
-header {
-    width: 100%;
-    background: #343a40;
-    color: #fff;
-    padding: 15px 20px;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
+.panel {
+  margin: 20px auto;
 }
 
-header .logo {
-    font-size: 24px;
-    font-weight: bold;
+.callout {
+  background: #eef4ff;
 }
 
-header nav ul {
-    list-style: none;
-    display: flex;
-    margin: 0;
-    padding: 0;
+.tip {
+  background: #f0fff4;
 }
 
-header nav ul li {
-    margin-left: 20px;
+.highlight {
+  background: var(--highlight);
 }
 
-header nav ul li a {
-    color: #fff;
-    text-decoration: none;
+.specific {
+  background: #fff8e6;
 }
 
-/* ======================
-   Hero Section
-   ====================== */
-#hero {
-    width: 100%;
-    /* Added a dark overlay for better contrast */
-    background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('hero-background.jpg') no-repeat center center/cover;
-    color: #fff;
-    padding: 60px 20px;
-    text-align: center;
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
 }
 
-#hero h1 {
-    font-size: 48px;
-    margin-bottom: 20px;
-}
-
-#hero p {
-    font-size: 20px;
-    margin-bottom: 30px;
-}
-
-#hero .btn {
-    background: #ff6600;
-    color: #fff;
-    padding: 12px 30px;
-    text-decoration: none;
-    border-radius: 5px;
-    font-size: 18px;
-}
-
-/* ======================
-   Section Content (if needed)
-   ====================== */
-.section-content {
-    background: #f4f4f4;
-    padding: 40px 20px;
-    margin: 20px 0;
-    border-radius: 5px;
-    text-align: left;
-}
-
-.section-content h2 {
-    text-align: center;
-    margin-bottom: 20px;
-}
-
-/* ======================
-   About Section
-   ====================== */
-#about p {
-    font-size: 18px;
-    line-height: 1.5;
-}
-
-/* ======================
-   Tool Interface Section
-   ====================== */
-#tool-interface {
-    padding: 40px 0;
-}
-
-#textInput {
-    width: 80%;
-    max-width: 800px;
-    height: 150px;
-    margin: 10px auto;
-    padding: 10px;
-    font-size: 16px;
-    border: 2px solid #6c757d;
-    border-radius: 5px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    resize: none;
-}
-
-#textDisplay {
-    width: 80%;
-    max-width: 800px;
-    margin: 10px auto;
-    padding: 10px;
-    font-size: 16px;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    min-height: 150px;
-    text-align: left;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    display: none;
-    cursor: pointer;
-    background: #fff;
-}
-
-.button-container {
-    display: flex;
-    justify-content: center;
-    gap: 15px;
-    margin-top: 15px;
-}
-
+.btn,
 button {
-    font-size: 16px;
-    padding: 10px 20px;
-    cursor: pointer;
-    border: none;
-    border-radius: 5px;
-    background: #007bff;
-    color: white;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    transition: background 0.3s, box-shadow 0.3s, color 0.3s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 10px 20px rgba(31, 94, 255, 0.2);
 }
 
+.btn:hover,
 button:hover {
-    background: #0056b3;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-    color: #e2e6ea;
+  background: var(--primary-dark);
+  transform: translateY(-1px);
 }
 
-select {
-    font-size: 16px;
-    padding: 5px;
-    margin: 10px;
-    border: 2px solid #6c757d;
-    border-radius: 5px;
-    background: #fff;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+.btn.secondary,
+button.secondary {
+  background: var(--surface-muted);
+  color: var(--text);
+  box-shadow: none;
+  border: 1px solid var(--border);
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  max-width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  font-size: 1rem;
+  font-family: inherit;
+  background: #fff;
 }
 
 label {
-    font-weight: bold;
+  font-weight: 600;
+  color: var(--muted);
 }
 
-/* ======================
-   Benefits / Use-Cases Section
-   ====================== */
-#benefits {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-around;
-    gap: 20px;
-    padding: 40px 0;
-    background: #fff;
+progress {
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  border: none;
+  background: var(--surface-muted);
 }
 
-.benefit {
-    flex: 1 1 250px;
-    padding: 20px;
-    background: #fff;
-    border: 1px solid #ddd;
-    border-radius: 5px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+progress::-webkit-progress-value {
+  background: var(--primary);
 }
 
-.benefit h3 {
-    margin-bottom: 10px;
+#supportBar {
+  max-width: var(--max-width);
+  margin: 16px auto 0;
+  padding: 12px 20px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  position: relative;
+  overflow: hidden;
 }
 
-/* ======================
-   Footer
-   ====================== */
-footer {
-    width: 100%;
-    background: #343a40;
-    color: #fff;
-    text-align: center;
-    padding: 20px 10px;
+#supportBar .fill {
+  position: absolute;
+  inset: 0;
+  background: rgba(31, 94, 255, 0.12);
+  transform-origin: left;
 }
 
-footer nav ul {
-    list-style: none;
-    display: flex;
-    justify-content: center;
-    gap: 20px;
-    margin: 10px 0 0;
-    padding: 0;
+#supportBar .msg,
+#supportBar .coffeeBtn {
+  position: relative;
+  z-index: 1;
 }
 
-footer nav ul li a {
-    color: #fff;
-    text-decoration: none;
+.coffeeBtn {
+  font-weight: 600;
+  color: var(--primary);
 }
 
-/* ======================
-   Progress Container
-   ====================== */
-#progressContainer {
-    position: fixed;
-    bottom: 10px;
-    right: 10px;
-    background: #f8f9fa;
-    padding: 10px;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    text-align: left;
-    z-index: 1000;
+.content h2,
+.content h3 {
+  margin-top: 0;
 }
 
-/* ======================
-   Highlight for current word (if used by TTS script)
-   ====================== */
-.highlight {
-    background-color: yellow;
+.meta {
+  color: var(--muted);
 }
 
-/* ======================
-   Responsive / Mobile Styles
-   ====================== */
-@media (max-width: 768px) {
-    header {
-        flex-direction: column;
-        align-items: center;
-    }
-    header nav ul {
-        flex-direction: column;
-        gap: 10px;
-        margin-top: 10px;
-    }
-    #textInput, #textDisplay {
-        width: 90%;
-        font-size: 14px;
-    }
-    .button-container {
-        flex-wrap: wrap;
-        gap: 10px;
-        justify-content: space-evenly;
-    }
-    button {
-        flex: 1 1 calc(45% - 10px);
-        max-width: 100px;
-        font-size: 14px;
-        padding: 8px 12px;
-    }
-    #benefits {
-        flex-direction: column;
-    }
-    /* Adjust progress container for mobile */
-    #progressContainer {
-        bottom: 5%;
-        right: 5%;
-        width: 90%;
-        padding: 5px;
-        background: #007bff;
-        border: none;
-        border-radius: 5px;
-    }
-    #progressContainer > * {
-        display: none;
-    }
+.muted {
+  color: var(--muted);
+}
+
+.tag {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(31, 94, 255, 0.12);
+  color: var(--primary-dark);
+  margin-right: 6px;
+}
+
+.template {
+  background: #f3f6ff;
+  border-left: 4px solid var(--primary);
+  padding: 14px 16px;
+  border-radius: 10px;
+}
+
+.demo {
+  background: #f9fbff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+}
+
+.note {
+  background: #f6f7fb;
+  border-left: 4px solid var(--primary);
+  padding: 12px 16px;
+}
+
+.ad-slot {
+  max-width: var(--max-width);
+  margin: 20px auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 80px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  color: var(--muted);
+  background: var(--surface);
+}
+
+.cookie-banner {
+  position: fixed;
+  inset: auto 16px 16px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 100;
+}
+
+.cookie-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.cookie-banner__actions button {
+  flex: 1 1 120px;
+}
+
+.cookie-banner__actions button.secondary {
+  background: var(--surface-muted);
+  color: var(--text);
+  box-shadow: none;
+  border: 1px solid var(--border);
+}
+
+@media (max-width: 640px) {
+  .nav-container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  #supportBar {
+    margin: 12px 16px 0;
+  }
+
+  main {
+    padding: 24px 16px 40px;
+  }
 }

--- a/terms.html
+++ b/terms.html
@@ -1,50 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Terms of Use | Read‑Aloud</title>
 <link rel="canonical" href="https://read-aloud.com/terms.html">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Terms of Use for Read‑Aloud (read-aloud.com).">
-<style>
-  body{margin:0;font:16px/1.75 Arial,Helvetica,sans-serif;background:#fff;color:#111}
-  header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-  header a,footer a{color:#fff;text-decoration:none;margin:0 8px}
-  header a:hover,footer a:hover{text-decoration:underline}
-  main{max-width:980px;margin:auto;padding:24px}
-  h1{margin-top:0}
-  .small{color:#444;font-size:0.95em}
-  .box{background:#f7f7f7;border:1px solid #ddd;padding:12px;border-radius:10px}
-  .highlight{background:#fff7d6;border:1px solid #f0d36b;padding:12px;border-radius:10px}
-  ul{padding-left:20px}
-  hr{margin:24px 0}
-  code{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -168,8 +146,10 @@
   </p>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 </body>
 </html>

--- a/updates.html
+++ b/updates.html
@@ -7,8 +7,29 @@
   <link rel="canonical" href="https://read-aloud.com/updates/">
   <title>Updates | Read‑Aloud</title>
   <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 <body>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/" aria-current="page">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
+</header>
+
   <p>Redirecting to <a href="/updates/">/updates/</a>…</p>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
+</footer>
 </body>
 </html>

--- a/voices.html
+++ b/voices.html
@@ -1,47 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-SVGML1VGPG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-SVGML1VGPG');
-</script>
-
 <meta charset="utf-8">
 <title>Voice Gallery | Read-Aloud</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="description" content="Sample the most popular browser voices before you read text aloud. Click any button to hear a 5-second demo.">
 <link rel="canonical" href="https://read-aloud.com/voices.html">
-<style>
-body{margin:0;font:16px/1.5 Arial,Helvetica,sans-serif;background:#f9f9ff;color:#111}
-header,footer{background:#004080;color:#fff;padding:12px;text-align:center}
-header a,footer a{color:#fff;text-decoration:none;margin:0 6px}
-main{max-width:900px;margin:auto;padding:20px}
-h1{margin-top:0;text-align:center}
-.small{font-size:0.9em;color:#e0e0e0}
-.grid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
-.voice card{background:#fff;border:1px solid #ddd;border-radius:6px;padding:12px}
-button.demo{width:100%;padding:10px;background:#ff0;border:2px solid #777;cursor:pointer;font:15px/1.2 Tahoma;color:#000}
-</style>
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
 </head>
 
 <body>
-<header>
-  <nav id="mainNav">
-    <a href="/index.html">Home</a>
-    <a href="/voices.html">Voices</a>
-    <a href="/help.html">Help</a>
-    <a href="/guides.html">Guides</a>
-    <a href="/blog/">Blog</a>
-    <a href="/recommendations.html">Resources</a>
-    <a href="/about.html">About</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-  </nav>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read‑Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html" aria-current="page">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
 </header>
 
 <main>
@@ -60,8 +41,10 @@ button.demo{width:100%;padding:10px;background:#ff0;border:2px solid #777;cursor
   </ul>
 </main>
 
-<footer>
-  © 2025 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a><br>
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2025 Read‑Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
 </footer>
 
 <script>


### PR DESCRIPTION
### Motivation
- Remove inconsistent inline styling and provide a single shared design system so pages stay visually consistent.
- Prevent analytics and ads from loading before user consent and provide both `Accept` and `Reject` options that persist across pages.
- Streamline header navigation into a concise primary nav and move legal links into the footer for clearer UX.
- Add a way to reset cookie preferences from the privacy page so users can change their choice later.

### Description
- Replaced per-page inline `<style>` blocks with a unified `/styles.css` and updated pages to include `<link rel="stylesheet" href="/styles.css">` and `<script src="/cookie-consent.js" defer></script>` where needed.
- Added `cookie-consent.js` to show a consent banner with `Accept` and `Reject`, persist choice in `localStorage` under key `ra_cookie_consent`, and only inject Google Analytics (`G-SVGML1VGPG`) and AdSense into the DOM after `Accept`.
- Standardized header and footer across all HTML pages (e.g. `index.html`, `blog/index.html`, `privacy.html`, all `guide-*.html`), moved `Privacy`/`Terms` into the footer, and applied `aria-current="page"` to indicate the active page.
- Placed an ad placeholder `#adsense-slot` on the homepage which `cookie-consent.js` will populate after consent, and added a `Reset cookie preferences` button on `privacy.html` wired to re-show the banner.

### Testing
- Repo-wide checks verified removal of inline `<style>` blocks and immediate `gtag`/AdSense snippets by searching for those patterns and finding none after the change (success).
- Launched a local static server and ran a Playwright smoke test that loaded `http://127.0.0.1:8000/index.html` and captured a full-page screenshot to confirm the page renders (screenshot artifact produced).
- Performed a quick manual smoke check of the homepage to confirm `cookie-consent.js` is included and the ad placeholder exists (script loaded; banner can display on first visit).
- Confirmed files updated include `styles.css`, `cookie-consent.js`, `index.html`, `privacy.html`, `blog/index.html`, and many `guide-*.html` pages (all HTML files were updated to use the shared stylesheet and consent script) and the changes were committed to the working tree (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee677a42083318ddae34a5c56ad63)