### PR TITLE
Configure Jekyll build and GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Install Jekyll
+        run: |
+          gem install bundler jekyll
+      - name: Build with Jekyll
+        run: jekyll build --destination _site
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,10 @@ build/
 tmp/
 temp/
 *.swp
+
+# Jekyll build artifacts
+_site/
+.jekyll-cache/
+.sass-cache/
+.bundle/
+vendor/

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,6 @@
+title: "Read Aloud"
+description: "Read Aloud website"
+url: "https://read-aloud.com"
+baseurl: ""
+markdown: kramdown
+permalink: pretty

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>
+      {% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}
+    </title>
+  </head>
+  <body>
+    {{ content }}
+  </body>
+</html>

--- a/jekyll-healthcheck.md
+++ b/jekyll-healthcheck.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: "Home"
+permalink: /jekyll-healthcheck/
+---
+
+Site build pipeline enabled.


### PR DESCRIPTION
### Motivation

- Enable automatic build and deployment of the site with Jekyll via GitHub Actions on pushes to `main`.
- Provide minimal Jekyll scaffolding so the site can render even though the repository already contains an `index.html`.
- Prevent Jekyll build artifacts from being committed by updating `.gitignore`.
- Keep changes minimal and safe with no blog content or plugins added.

### Description

- Add workflow `/.github/workflows/pages.yml` to build the site with Jekyll and deploy to GitHub Pages using `actions/checkout@v4`, `ruby/setup-ruby@v1`, `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3`, and `actions/deploy-pages@v4`.
- Add minimal site configuration in `_config.yml` with `title`, `description`, `url`, `baseurl`, `markdown: kramdown`, and `permalink: pretty`.
- Add `_layouts/default.html` containing a basic HTML skeleton with `{{ content }}` and add `jekyll-healthcheck.md` with front matter and `permalink: /jekyll-healthcheck/` to avoid overwriting the existing `index.html`.
- Update `.gitignore` to ignore Jekyll build outputs: `_site/`, `.jekyll-cache/`, `.sass-cache/`, `.bundle/`, and `vendor/`.

### Testing

- No automated tests or workflow runs were executed as part of this change (the Pages workflow will run when this is pushed to `main` or triggered manually).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc00ee9dc8331b4c44d7f23e7bf67)