### PR TITLE
Use Bundler for Jekyll Pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,11 +26,8 @@ jobs:
         with:
           ruby-version: '3.2'
           bundler-cache: true
-      - name: Install Jekyll
-        run: |
-          gem install bundler jekyll
       - name: Build with Jekyll
-        run: jekyll build --destination _site
+        run: bundle exec jekyll build --destination _site
       - name: Configure Pages
         uses: actions/configure-pages@v5
       - name: Upload Pages artifact

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"


### PR DESCRIPTION
### Motivation
- Make the GitHub Pages build reliable by switching to a Bundler-managed Jekyll build so dependency caching works.
- Ensure the workflow uses the repository `Gemfile` rather than installing Jekyll globally in the runner.
- Prepare the repo for future post publishing via the standard `bundle exec` Jekyll workflow.

### Description
- Add a `Gemfile` at the repo root with `source "https://rubygems.org"` and `gem "jekyll", "~> 4.3"` to declare Jekyll as a Bundler dependency.
- Update `.github/workflows/pages.yml` to keep `ruby/setup-ruby@v1` with `ruby-version: '3.2'` and `bundler-cache: true` and to remove the standalone `gem install bundler jekyll` step.
- Replace the build command from `jekyll build --destination _site` to `bundle exec jekyll build --destination _site` so Bundler drives the build.
- No themes or plugins were added or modified in this change.

### Testing
- No automated CI tests were executed in this environment; the GitHub Actions workflow will run on push to `main` and should be used to validate the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc42bb4c483319a34b3ede3645f4f)