### PR TITLE
Fix Pages workflow order, lock gems, and build Jekyll in production

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,15 +21,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
       - name: Build with Jekyll
+        env:
+          JEKYLL_ENV: production
         run: bundle exec jekyll build --destination _site
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,161 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.6)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86-linux-gnu)
+    ffi (1.17.3-x86-linux-musl)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.33.2)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.18.0)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (7.0.2)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.7.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.97.2)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.97.2-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+
+BUNDLED WITH
+   2.6.7


### PR DESCRIPTION
### Motivation
- Ensure GitHub Pages are configured before the Jekyll build step so the Pages action runs in the correct order.
- Make the Jekyll build run with production settings to produce a production-accurate site output.
- Provide reproducible Bundler installs by committing a `Gemfile.lock` so CI uses pinned dependency versions.

### Description
- Edited `.github/workflows/pages.yml` to move the `actions/configure-pages@v5` step immediately after `actions/checkout@v4` and before Ruby setup. 
- Updated the `Build with Jekyll` step to include `env: JEKYLL_ENV: production` and kept `ruby-version: '3.2'` and `bundler-cache: true` intact. 
- Generated `Gemfile.lock` with `bundle lock` and added it to the repository to lock Jekyll and related gems. 
- Kept upload and deploy steps unchanged.

### Testing
- Ran `bundle lock` to produce `Gemfile.lock`, which completed successfully. 
- Ran `bundle install` to install dependencies required for the build, which completed successfully. 
- Ran `bundle exec jekyll build --destination _site` to validate the build, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fcf147f548331b90b518a4146ef2c)