### PR TITLE
Add Jekyll blog post layout and dynamic blog index

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,12 @@ url: "https://read-aloud.com"
 baseurl: ""
 markdown: kramdown
 permalink: pretty
+
+# Blog posts (Markdown in _posts/) publish to /blog/<slug>/
+defaults:
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: blog_post
+      permalink: /blog/:title/

--- a/_layouts/blog_post.html
+++ b/_layouts/blog_post.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{ page.title }} | Read-Aloud</title>
+  <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="{{ page.description | default: site.description | escape }}">
+  <link rel="stylesheet" href="/styles.css">
+  <script src="/cookie-consent.js" defer></script>
+
+  {% if page.noindex %}
+  <meta name="robots" content="noindex">
+  {% endif %}
+
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"Article",
+    "headline": {{ page.title | jsonify }},
+    "description": {{ page.description | default: site.description | jsonify }},
+    "author": {"@type":"Person","name": {{ page.author | default: "Read-Aloud" | jsonify }}},
+    "publisher": {"@type":"Organization","name":"Read-Aloud","url":"{{ site.url }}/"},
+    "datePublished":"{{ page.date | date: "%Y-%m-%d" }}",
+    "mainEntityOfPage":"{{ site.url }}{{ page.url }}"
+  }
+  </script>
+</head>
+
+<body>
+<header class="site-header">
+  <div class="nav-container">
+    <a class="logo" href="/index.html">Read-Aloud</a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/guides.html">Guides</a>
+      <a href="/voices.html">Voices</a>
+      <a href="/help.html">Help</a>
+      <a href="/blog/" aria-current="page">Blog</a>
+      <a href="/recommendations.html">Resources</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <article class="panel content">
+    {% if page.tags %}
+      {% for tag in page.tags %}
+        <span class="tag">{{ tag }}</span>
+      {% endfor %}
+    {% endif %}
+
+    <h1>{{ page.title }}</h1>
+
+    {% assign words = content | strip_html | strip_newlines | split: " " | size %}
+    {% assign minutes = words | plus: 199 | divided_by: 200 %}
+    <p class="meta">
+      <strong>Published:</strong> {{ page.date | date: "%B %Y" }}
+      {% if page.author %} · <strong>Author:</strong> {{ page.author }}{% endif %}
+      · <strong>Reading time:</strong> ~{{ minutes }} min read · <a href="/blog/">Blog</a>
+    </p>
+
+    {{ content }}
+  </article>
+</main>
+
+<footer class="site-footer">
+  <div class="footer-container">
+    <span>© 2026 Read-Aloud</span> · <a href="/about.html">About</a> · <a href="/contact.html">Contact</a> · <a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a>
+  </div>
+</footer>
+</body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,3 +1,7 @@
+---
+layout: null
+---
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -41,18 +45,38 @@
   <div class="grid">
     <section class="card" aria-label="Latest posts">
       <h2>Latest posts</h2>
+      {% assign posts = site.posts | sort: "date" | reverse %}
+      {% if posts.size == 0 %}
+        <p class="small">No posts yet. Check back soon.</p>
+      {% else %}
+        {% assign pinned_url = "/blog/local-vs-cloud-text-to-speech/" %}
+        {% assign pinned = posts | where_exp: "p", "p.url == pinned_url" | first %}
+        {% if pinned == nil %}
+          <p>
+            <span class="tag">Privacy &amp; Trust</span>
+            <a href="/blog/local-vs-cloud-text-to-speech/"><strong>Local vs Cloud Text‑to‑Speech: A Decision Guide for Privacy, Voice Quality, and Trust</strong></a>
+          </p>
+          <p class="meta">Published: January 2026 · ~5 min read</p>
+          <hr>
+        {% endif %}
 
-      <p>
-        <span class="tag">Privacy &amp; Trust</span>
-        <a href="/blog/local-vs-cloud-text-to-speech/"><strong>Local vs Cloud Text‑to‑Speech: A Decision Guide for Privacy, Voice Quality, and Trust</strong></a>
-      </p>
-      <p class="meta">Published: January 2026 · ~5 min read</p>
-
-      <hr>
-
-      <p class="small">
-        Coming next: voice installation guides, troubleshooting deep dives, and real study/proofreading workflows.
-      </p>
+        {% for post in posts limit: 10 %}
+          <p>
+            {% if post.tags %}
+              <span class="tag">{{ post.tags | first }}</span>
+            {% endif %}
+            <a href="{{ post.url }}"><strong>{{ post.title }}</strong></a>
+          </p>
+          {% assign words = post.content | strip_html | strip_newlines | split: " " | size %}
+          {% assign minutes = words | plus: 199 | divided_by: 200 %}
+          <p class="meta">
+            Published: {{ post.date | date: "%B %Y" }}
+            {% if post.author %} · {{ post.author }}{% endif %}
+            · ~{{ minutes }} min read
+          </p>
+          {% unless forloop.last %}<hr>{% endunless %}
+        {% endfor %}
+      {% endif %}
     </section>
 
     <aside class="card" aria-label="Updates">


### PR DESCRIPTION
### Motivation
- Provide a dedicated layout and URL scheme so Markdown posts under `_posts/` publish cleanly under `/blog/`.
- Ensure blog posts include consistent metadata (title, author, tags, reading time) and structured data for SEO.
- Replace hard-coded blog index content with a dynamic listing of site posts and a pinned fallback for the initial featured article.

### Description
- Added Jekyll defaults to `_config.yml` so posts use the new `blog_post` layout and publish under `/blog/:title/`.
- Created a new layout ` _layouts/blog_post.html` that renders tags, metadata, reading-time calculation, and JSON-LD article data.
- Updated `blog/index.html` to render the latest posts from `site.posts` (sorted/reversed) with a pinned fallback and a 10-post limit.

### Testing
- Ran `bundle install` to install dependencies, which completed successfully. 
- Ran `bundle exec jekyll build`, which completed successfully (the build emitted warnings about some posts still requesting the old `post` layout). 
- Performed a headless render of `/blog/` with Playwright and captured a screenshot to verify the index renders; the render succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962579fd2bc833191819285b9da7244)