### PR TITLE
Remove 'Updates' teaser from blog landing page

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -116,15 +116,6 @@ layout: null
     </nav>
   </section>
 
-  <section class="updates-teaser" aria-label="Updates">
-    <div>
-      <h2>Updates</h2>
-      <p class="small">Short notes about changes to Read‑Aloud. Visit the changelog for fixes, improvements, and new guides.</p>
-      <p class="meta"><span class="tag">Site</span> <a href="/updates/#2026-01">January 2026: Blog &amp; Updates section launched</a></p>
-    </div>
-    <a class="btn secondary" href="/updates/">View all updates</a>
-  </section>
-
   <p class="small">
     Suggestions for what to write next? <a href="/contact.html">Send feedback</a>.
   </p>


### PR DESCRIPTION
### Motivation
- Remove the site-level "Updates" teaser from the blog landing page to simplify the page layout and reduce duplication with the main changelog.
- Let the blog flow directly from the posts pagination into the feedback prompt for a cleaner user experience.
- Keep changelog access via the existing `/updates/` page instead of a small teaser on the blog index.

### Description
- Deleted the `<section class="updates-teaser">` block from `blog/index.html` so the teaser no longer renders.
- No JavaScript or stylesheet changes were required as this is a static markup removal.
- Change was committed with the message `Remove updates teaser from blog`.

### Testing
- Served the site with `python -m http.server` and the server started successfully.
- Ran a Playwright script to load `http://127.0.0.1:8000/blog/` and capture a screenshot which confirmed the teaser was removed (succeeded).
- Committed the change to the local branch with `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628ed1df6083319b18597c0f34af60)