### PR TITLE
Remove blog updates teaser section

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -116,15 +116,6 @@ layout: null
     </nav>
   </section>
 
-  <section class="updates-teaser" aria-label="Updates">
-    <div>
-      <h2>Updates</h2>
-      <p class="small">Short notes about changes to Read‑Aloud. Visit the changelog for fixes, improvements, and new guides.</p>
-      <p class="meta"><span class="tag">Site</span> <a href="/updates/#2026-01">January 2026: Blog &amp; Updates section launched</a></p>
-    </div>
-    <a class="btn secondary" href="/updates/">View all updates</a>
-  </section>
-
   <p class="small">
     Suggestions for what to write next? <a href="/contact.html">Send feedback</a>.
   </p>


### PR DESCRIPTION
### Motivation
- Remove the site "Updates" teaser from the blog index so the page presents only posts and reduces duplicate links to the `/updates/` page.
- The teaser was a small informational block linking to the changelog and a single historic update entry.

### Description
- Deleted the `<section class="updates-teaser">` block from `blog/index.html` to remove the Updates teaser from the page.
- No other files were modified.

### Testing
- No automated tests were run for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628ed1df6083319b18597c0f34af60)