### PR TITLE
Remove placeholder front matter from blog posts

### DIFF
--- a/_posts/2025-08-15----.md
+++ b/_posts/2025-08-15----.md
@@ -1,14 +1,4 @@
 ---
-title: "---"
-description: "---"
-date: 2025-08-15
-author: "Read-Aloud"
-tags: []
-categories: []
-permalink: "/blog/---/"
----
-
----
 title: "Weekly Review by Ear"
 description: "Turn a messy week into three clean decisions in ten minutes"
 date: "2026-01-08 09:00:00 -0500"

--- a/_posts/2025-08-18----.md
+++ b/_posts/2025-08-18----.md
@@ -1,14 +1,4 @@
 ---
-title: "---"
-description: "---"
-date: 2025-08-18
-author: "Read-Aloud"
-tags: []
-categories: []
-permalink: "/blog/---/"
----
-
----
 title: "Postmortem by Ear"
 description: "Make the timeline coherent, make the fixes real, and stop repeating the same incident with new wording"
 date: "2026-01-11 09:00:00 -0500"

--- a/_posts/2025-08-27----.md
+++ b/_posts/2025-08-27----.md
@@ -1,14 +1,4 @@
 ---
-title: "---"
-description: "---"
-date: 2025-08-27
-author: "Read-Aloud"
-tags: []
-categories: []
-permalink: "/blog/---/"
----
-
----
 title: "Write an Executive Summary That Survives Forwarding"
 description: "Clear, calibrated, and useful—without hype"
 date: "2026-01-15 09:00:00 -0500"

--- a/_posts/2025-09-01----.md
+++ b/_posts/2025-09-01----.md
@@ -1,14 +1,4 @@
 ---
-title: "---"
-description: "---"
-date: 2025-09-01
-author: "Read-Aloud"
-tags: []
-categories: []
-permalink: "/blog/---/"
----
-
----
 title: "Great next step"
 description: "The 30‑Second Teach‑Back"
 date: "2026-01-12 09:00:00 -0500"

--- a/_posts/2025-09-18----.md
+++ b/_posts/2025-09-18----.md
@@ -1,14 +1,4 @@
 ---
-title: "---"
-description: "---"
-date: 2025-09-18
-author: "Read-Aloud"
-tags: []
-categories: []
-permalink: "/blog/---/"
----
-
----
 title: "Audio Flashcards for Adults"
 description: "Turn your notes into recall prompts you can listen to (so you can actually use what you learn)"
 date: "2026-01-14 09:00:00 -0500"

--- a/_posts/2025-10-28----.md
+++ b/_posts/2025-10-28----.md
@@ -1,14 +1,4 @@
 ---
-title: "---"
-description: "---"
-date: 2025-10-28
-author: "Read-Aloud"
-tags: []
-categories: []
-permalink: "/blog/---/"
----
-
----
 title: "Before You Negotiate: Write a One‑Page Ask You Can Say Out Loud"
 description: "The easiest way to stop “winging it” and start getting clean outcomes"
 date: "2026-01-16 09:00:00 -0500"

--- a/_posts/2025-11-26----.md
+++ b/_posts/2025-11-26----.md
@@ -1,14 +1,4 @@
 ---
-title: "---"
-description: "---"
-date: 2025-11-26
-author: "Read-Aloud"
-tags: []
-categories: []
-permalink: "/blog/---/"
----
-
----
 title: "Customer Support Replies That De‑Escalate"
 description: "Turn a frustrated ticket into a calm, clear answer that doesn’t create more tickets"
 date: "2026-01-13 09:00:00 -0500"

--- a/_posts/2025-12-14----.md
+++ b/_posts/2025-12-14----.md
@@ -1,14 +1,4 @@
 ---
-title: "---"
-description: "---"
-date: 2025-12-14
-author: "Read-Aloud"
-tags: []
-categories: []
-permalink: "/blog/---/"
----
-
----
 title: "Practice Interview Answers with Text‑to‑Speech"
 description: "Cut the wandering, keep the story, and land the point in under two minutes"
 date: "2026-01-10 09:00:00 -0500"

--- a/_posts/2025-12-22----.md
+++ b/_posts/2025-12-22----.md
@@ -1,14 +1,4 @@
 ---
-title: "---"
-description: "---"
-date: 2025-12-22
-author: "Read-Aloud"
-tags: []
-categories: []
-permalink: "/blog/---/"
----
-
----
 title: "The Contract / Terms Clarity Pass"
 description: "Listen for the clauses that create surprise bills and surprise obligations"
 date: "2026-01-09 09:00:00 -0500"

--- a/_posts/2026-01-08----.md
+++ b/_posts/2026-01-08----.md
@@ -1,14 +1,4 @@
 ---
-title: "---"
-description: "---"
-date: 2026-01-08
-author: "Read-Aloud"
-tags: []
-categories: []
-permalink: "/blog/---/"
----
-
----
 title: "Make a 5‑Minute Audio Brief From Any Long Doc"
 description: "So your best thinking doesn’t disappear into a tab you’ll never reopen"
 date: "2026-01-17 09:00:00 -0500"


### PR DESCRIPTION
### Motivation
- Remove redundant placeholder front-matter blocks that duplicated `---` metadata and produced duplicate titles/slugs in rendered posts.
- Each post already contained the article’s real metadata at the top, so the placeholders were unnecessary and could cause permalink collisions.

### Description
- Deleted the placeholder front-matter blocks from 10 post files so only the article’s real YAML front matter remains.
- Files changed: `_posts/2025-08-15----.md`, `_posts/2025-08-18----.md`, `_posts/2025-08-27----.md`, `_posts/2025-09-01----.md`, `_posts/2025-09-18----.md`, `_posts/2025-10-28----.md`, `_posts/2025-11-26----.md`, `_posts/2025-12-14----.md`, `_posts/2025-12-22----.md`, and `_posts/2026-01-08----.md`. 
- Commit message: `Remove placeholder front matter from posts` and changes totalled 10 files updated.

### Testing
- No automated tests were run because these are content-only front-matter edits and do not affect application code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ba14a769c83319b51b4937a9af16e)