### PR TITLE
Add unique slugs for upcoming posts

### DIFF
--- a/_posts/2025-08-15----.md
+++ b/_posts/2025-08-15----.md
@@ -3,6 +3,7 @@ title: "Weekly Review by Ear"
 description: "Turn a messy week into three clean decisions in ten minutes"
 date: "2026-01-08 09:00:00 -0500"
 author: "Nick Daly"
+slug: "weekly-review-by-ear"
 topic: "Workflows"
 category: "Workflows"
 categories: ["Workflows"]

--- a/_posts/2025-08-18----.md
+++ b/_posts/2025-08-18----.md
@@ -3,6 +3,7 @@ title: "Postmortem by Ear"
 description: "Make the timeline coherent, make the fixes real, and stop repeating the same incident with new wording"
 date: "2026-01-11 09:00:00 -0500"
 author: "Nick Daly"
+slug: "postmortem-by-ear"
 topic: "Operations"
 category: "Operations"
 categories: ["Operations"]

--- a/_posts/2025-08-27----.md
+++ b/_posts/2025-08-27----.md
@@ -3,6 +3,7 @@ title: "Write an Executive Summary That Survives Forwarding"
 description: "Clear, calibrated, and useful—without hype"
 date: "2026-01-15 09:00:00 -0500"
 author: "Nick Daly"
+slug: "executive-summary-that-survives-forwarding"
 topic: "Writing"
 category: "Writing"
 categories: ["Writing"]

--- a/_posts/2025-09-01----.md
+++ b/_posts/2025-09-01----.md
@@ -3,6 +3,7 @@ title: "Great next step"
 description: "The 30‑Second Teach‑Back"
 date: "2026-01-12 09:00:00 -0500"
 author: "Nick Daly"
+slug: "30-second-teach-back"
 topic: "Workflows"
 category: "Workflows"
 categories: ["Workflows"]

--- a/_posts/2025-09-18----.md
+++ b/_posts/2025-09-18----.md
@@ -3,6 +3,7 @@ title: "Audio Flashcards for Adults"
 description: "Turn your notes into recall prompts you can listen to (so you can actually use what you learn)"
 date: "2026-01-14 09:00:00 -0500"
 author: "Nick Daly"
+slug: "audio-flashcards-for-adults"
 topic: "Study"
 category: "Study"
 categories: ["Study"]

--- a/_posts/2025-10-28----.md
+++ b/_posts/2025-10-28----.md
@@ -3,6 +3,7 @@ title: "Before You Negotiate: Write a One‑Page Ask You Can Say Out Loud"
 description: "The easiest way to stop “winging it” and start getting clean outcomes"
 date: "2026-01-16 09:00:00 -0500"
 author: "Nick Daly"
+slug: "before-you-negotiate-one-page-ask"
 topic: "Career"
 category: "Career"
 categories: ["Career"]

--- a/_posts/2025-11-26----.md
+++ b/_posts/2025-11-26----.md
@@ -3,6 +3,7 @@ title: "Customer Support Replies That De‑Escalate"
 description: "Turn a frustrated ticket into a calm, clear answer that doesn’t create more tickets"
 date: "2026-01-13 09:00:00 -0500"
 author: "Nick Daly"
+slug: "customer-support-replies-that-deescalate"
 topic: "Email"
 category: "Email"
 categories: ["Email"]

--- a/_posts/2025-12-14----.md
+++ b/_posts/2025-12-14----.md
@@ -3,6 +3,7 @@ title: "Practice Interview Answers with Text‑to‑Speech"
 description: "Cut the wandering, keep the story, and land the point in under two minutes"
 date: "2026-01-10 09:00:00 -0500"
 author: "Nick Daly"
+slug: "practice-interview-answers-by-ear"
 topic: "Career"
 category: "Career"
 categories: ["Career"]

--- a/_posts/2025-12-22----.md
+++ b/_posts/2025-12-22----.md
@@ -3,6 +3,7 @@ title: "The Contract / Terms Clarity Pass"
 description: "Listen for the clauses that create surprise bills and surprise obligations"
 date: "2026-01-09 09:00:00 -0500"
 author: "Nick Daly"
+slug: "contract-terms-clarity-pass"
 topic: "Workflows"
 category: "Workflows"
 categories: ["Workflows"]

--- a/_posts/2026-01-08----.md
+++ b/_posts/2026-01-08----.md
@@ -3,6 +3,7 @@ title: "Make a 5‑Minute Audio Brief From Any Long Doc"
 description: "So your best thinking doesn’t disappear into a tab you’ll never reopen"
 date: "2026-01-17 09:00:00 -0500"
 author: "Nick Daly"
+slug: "make-5-minute-audio-brief"
 topic: "Study"
 category: "Study"
 categories: ["Study"]


### PR DESCRIPTION
### Motivation
- The site build failed due to the duplicate-post guard detecting repeated empty/placeholder slugs (slug '---') in scheduled `_posts` files, causing `jekyll build` to abort. 
- The fix is to ensure each scheduled/placeholder post has an explicit `slug` in its front matter so the guardrail can validate uniqueness.

### Description
- Add explicit `slug` front-matter to ten scheduled posts that used placeholder filenames to ensure unique slugs (files updated: `_posts/2025-08-15----.md`, `_posts/2025-08-18----.md`, `_posts/2025-08-27----.md`, `_posts/2025-09-01----.md`, `_posts/2025-09-18----.md`, `_posts/2025-10-28----.md`, `_posts/2025-11-26----.md`, `_posts/2025-12-14----.md`, `_posts/2025-12-22----.md`, `_posts/2026-01-08----.md`).
- Each `slug` value was derived from the post `permalink` last segment (for example, `slug: "weekly-review-by-ear"`), and inserted into the YAML front matter near the `author`/`date` lines.
- This is a content-only change and does not modify any plugins or guard logic in `_plugins/duplicate_post_guard.rb`.

### Testing
- No automated tests were run against the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ba391209883318c6eacafa4908b9f)