### PR TITLE
Normalize internal guide links and refine privacy policy wording

### DIFF
--- a/about.html
+++ b/about.html
@@ -52,7 +52,7 @@
       <li><strong>Voices come from your browser/OS.</strong> That means the voice list can differ on Chrome vs Safari vs Firefox—and it can differ by device.</li>
       <li><strong>If a voice sounds robotic:</strong> try another voice, or try a different browser. (Desktop Chrome/Edge are often the most reliable.)</li>
       <li><strong>Offline use:</strong> once the page loads, system voices often keep working without an internet connection. If your browser has no voices, the fallback offline voice may require an initial download first.</li>
-      <li><strong>iPhone/iPad note:</strong> iOS can be strict about audio playback. If you hear nothing or the voice list is empty, check the troubleshooting steps on the <a href="help.html">Help</a> page.</li>
+      <li><strong>iPhone/iPad note:</strong> iOS can be strict about audio playback. If you hear nothing or the voice list is empty, check the troubleshooting steps on the <a href="/help.html">Help</a> page.</li>
     </ul>
     <p class="small">
       Deep dive: <a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability</a>
@@ -98,8 +98,8 @@
 
   <hr>
   <p class="small">
-    Next: <a href="guides.html">Guides</a> ·
-    <a href="help.html">Help</a> ·
+    Next: <a href="/guides.html">Guides</a> ·
+    <a href="/help.html">Help</a> ·
     <a href="/contact.html">Contact</a> ·
     <a href="/terms.html">Terms</a>
   </p>

--- a/guide-browser-compatibility.html
+++ b/guide-browser-compatibility.html
@@ -100,7 +100,7 @@
           <td>Uses iOS voices; audio requires a user action (tap Start).</td>
           <td>
             <strong>Issue:</strong> “Start” but no sound / voices empty.<br>
-            <strong>Fix:</strong> check Ring/Silent switch, disable Lockdown Mode, refresh, then tap Start again. See <a href="help.html">Help</a>.
+            <strong>Fix:</strong> check Ring/Silent switch, disable Lockdown Mode, refresh, then tap Start again. See <a href="/help.html">Help</a>.
           </td>
         </tr>
         <tr>
@@ -138,7 +138,7 @@
     <ul>
       <li><strong>Refresh once.</strong> Voice lists can load late.</li>
       <li><strong>Tap Start.</strong> On mobile, audio often requires a direct user action.</li>
-      <li><strong>iPhone/iPad:</strong> check Ring/Silent switch (not orange), disable Lockdown Mode, refresh, then tap Start again. (Full checklist: <a href="help.html">Help</a>.)</li>
+      <li><strong>iPhone/iPad:</strong> check Ring/Silent switch (not orange), disable Lockdown Mode, refresh, then tap Start again. (Full checklist: <a href="/help.html">Help</a>.)</li>
       <li><strong>Try another browser.</strong> Chrome/Edge/Safari can expose different voice lists.</li>
       <li><strong>Try another voice.</strong> Some voices sound robotic or handle punctuation differently.</li>
     </ul>
@@ -153,7 +153,7 @@
   <hr>
   <p class="small">
     Related: <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 

--- a/guide-dyslexia-adhd.html
+++ b/guide-dyslexia-adhd.html
@@ -112,7 +112,7 @@
   <p class="small">
     Next: <a href="guide-study.html">Study with TTS</a> ·
     <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 

--- a/guide-how-to-use.html
+++ b/guide-how-to-use.html
@@ -33,7 +33,7 @@
     <ul>
       <li><strong>Your voices come from your browser/OS.</strong> If your voice list looks different on another device or browser, that’s normal.</li>
       <li><strong>If a voice sounds robotic:</strong> try a different voice, or try another browser (desktop Chrome/Edge are often the most reliable).</li>
-      <li><strong>iPhone/iPad “no sound”:</strong> check <a href="help.html">Help</a> (Ring/Silent switch, Lockdown Mode, refresh, and tap <strong>Start</strong> again).</li>
+      <li><strong>iPhone/iPad “no sound”:</strong> check <a href="/help.html">Help</a> (Ring/Silent switch, Lockdown Mode, refresh, and tap <strong>Start</strong> again).</li>
     </ul>
     <p class="small">More detail: <a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability</a></p>
   </div>
@@ -78,7 +78,7 @@ Question: does it pause correctly after commas, periods, and question marks?</pr
 
   <h2>Common problems (and fixes)</h2>
   <ul>
-    <li><strong>“I pressed Start but hear nothing (iPhone/iPad)”</strong>: make sure the Ring/Silent switch isn’t set to silent, disable Lockdown Mode, refresh the page, then tap <strong>Start</strong> again. See <a href="help.html">Help</a>.</li>
+    <li><strong>“I pressed Start but hear nothing (iPhone/iPad)”</strong>: make sure the Ring/Silent switch isn’t set to silent, disable Lockdown Mode, refresh the page, then tap <strong>Start</strong> again. See <a href="/help.html">Help</a>.</li>
     <li><strong>“My voice list is empty”</strong>: refresh, tap <strong>Start</strong> once, then check again. If needed, try another browser or update your OS.</li>
     <li><strong>“It stops mid‑way through a long text”</strong>: split your text into smaller chunks (headings/sections) and play them one at a time.</li>
   </ul>
@@ -93,7 +93,7 @@ Question: does it pause correctly after commas, periods, and question marks?</pr
   <p class="small">
     Next: <a href="guide-study.html">Study with TTS</a> ·
     <a href="guide-proofread.html">Proofread by Ear</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 

--- a/guide-language-learning.html
+++ b/guide-language-learning.html
@@ -38,7 +38,7 @@
     <ul>
       <li><strong>Voice availability depends on your device.</strong> If you don’t see a voice for your target language, it usually means that language voice isn’t installed on your OS/browser.</li>
       <li><strong>If a voice sounds robotic:</strong> try another voice, or try another browser.</li>
-      <li><strong>iPhone/iPad tip:</strong> if audio is silent or voices don’t load, see <a href="help.html">Help</a>.</li>
+      <li><strong>iPhone/iPad tip:</strong> if audio is silent or voices don’t load, see <a href="/help.html">Help</a>.</li>
     </ul>
     <p class="small">Deep dive: <a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability</a></p>
   </div>
@@ -127,7 +127,7 @@ FRANÇAIS (French)
   <p class="small">
     Next: <a href="guide-study.html">Study with TTS</a> ·
     <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 

--- a/guide-privacy.html
+++ b/guide-privacy.html
@@ -58,7 +58,7 @@
   <div class="specific">
     <ul>
       <li><strong>Voices come from your device.</strong> Different browsers/OSes expose different voice lists.</li>
-      <li><strong>On iPhone/iPad:</strong> if audio is silent or voices don’t load, see <a href="help.html">Help</a>.</li>
+    <li><strong>On iPhone/iPad:</strong> if audio is silent or voices don’t load, see <a href="/help.html">Help</a>.</li>
       <li><strong>No file downloads.</strong> Read‑Aloud focuses on in‑browser playback and does not export audio files.</li>
     </ul>
     <p class="small">Deep dives: <a href="guide-browser-compatibility.html">Browser compatibility</a></p>
@@ -90,13 +90,13 @@
   <h2>Where to Learn More</h2>
   <ul>
     <li><a href="/privacy.html">Read‑Aloud Privacy Policy</a></li>
-    <li><a href="help.html">Help &amp; FAQ</a></li>
+    <li><a href="/help.html">Help &amp; FAQ</a></li>
   </ul>
 
   <hr>
   <p class="small">
     Next: <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 

--- a/guide-proofread.html
+++ b/guide-proofread.html
@@ -45,7 +45,7 @@
       <li><strong>Voices are device-dependent.</strong> If a voice sounds wrong, try another voice (or another browser).</li>
       <li><strong>Pro editing tip:</strong> slow down slightly (0.85×–0.95×). Your ears catch missing words better when speech is a bit slower.</li>
     </ul>
-    <p class="small">If your voice list is empty or iOS audio is silent, see <a href="help.html">Help</a>.</p>
+  <p class="small">If your voice list is empty or iOS audio is silent, see <a href="/help.html">Help</a>.</p>
   </div>
 
   <h2>Quick Proofreading Workflow (10 Minutes)</h2>
@@ -125,7 +125,7 @@
   <p class="small">
     Next: <a href="guide-how-to-use.html">How to Use Read‑Aloud</a> ·
     <a href="guide-study.html">Study with TTS</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 

--- a/guide-study.html
+++ b/guide-study.html
@@ -43,7 +43,7 @@
     <ul>
       <li><strong>Voices come from your browser/OS.</strong> If you don’t like how one voice sounds, switch voices (or try another browser).</li>
       <li><strong>Studying tip:</strong> for dense text, use a slightly slower speed (0.8×–0.95×) so you can summarize after each chunk.</li>
-      <li><strong>On iPhone/iPad:</strong> if you get no sound, see <a href="help.html">Help</a> (Ring/Silent switch, Lockdown Mode, refresh, tap Start again).</li>
+      <li><strong>On iPhone/iPad:</strong> if you get no sound, see <a href="/help.html">Help</a> (Ring/Silent switch, Lockdown Mode, refresh, tap Start again).</li>
     </ul>
     <p class="small">More detail: <a href="guide-browser-compatibility.html">Browser compatibility &amp; voice availability</a></p>
   </div>
@@ -140,7 +140,7 @@ Next step (choose one):
   <p class="small">
     Next: <a href="guide-dyslexia-adhd.html">TTS for Dyslexia &amp; ADHD</a> ·
     <a href="guide-proofread.html">Proofread by Ear</a> ·
-    <a href="guides.html">All Guides</a>
+    <a href="/guides.html">All Guides</a>
   </p>
 </main>
 

--- a/privacy.html
+++ b/privacy.html
@@ -26,127 +26,188 @@
 
 <main>
   <h1>Privacy Policy</h1>
-  <p class="small"><strong>Last updated:</strong> December 14, 2025</p>
+  <p class="small"><strong>Last updated:</strong> January 18, 2026</p>
 
   <div class="highlight">
-    <strong>Plain‑English summary:</strong>
+    <strong>Plain-English summary:</strong>
     <ul>
-      <li><strong>Your pasted text is spoken locally in your browser.</strong> We don’t upload your pasted text to our servers.</li>
-      <li>We don’t require accounts.</li>
-      <li>Analytics and ads only load after you accept the cookie banner. You can reset that choice anytime below.</li>
+      <li><strong>Your pasted text is spoken by your browser/operating system’s speech engine.</strong> We don’t upload your pasted text to our servers.</li>
+      <li><strong>No accounts.</strong> You can use the tool without signing in.</li>
+      <li><strong>Ads + Google Analytics only load if you accept.</strong> You can reject and still use the core tool.</li>
+      <li><strong>Two homepage services run regardless of the cookie banner:</strong> a voice fallback loaded from a CDN (meSpeak via jsDelivr) and a simple visit counter request (CountAPI).</li>
     </ul>
   </div>
 
-  <h2>1) No text leaves your browser</h2>
+  <h2>1) Who we are</h2>
   <p>
-    Read‑Aloud converts text to speech using your browser/operating system’s speech engine (Web Speech API).
-    In some cases, the site may also use an offline fallback voice (meSpeak).
-  </p>
-  <p>
-    <strong>We do not send the text you paste or type to our servers.</strong> The text stays in your browser so speech can be generated on your device.
+    This Privacy Policy applies to Read-Aloud (<strong>read-aloud.com</strong>) (“Read-Aloud”, “we”, “us”).
+    If you have questions, email <strong>admin@read-aloud.com</strong> or use the <a href="/contact.html">contact form</a>.
   </p>
 
-  <h2>2) Information we collect</h2>
+  <h2>2) The core tool runs locally (we don’t upload your pasted text)</h2>
+  <p>
+    Read-Aloud converts text to speech using your browser/operating system’s speech engine (via the Web Speech API).
+    Depending on the voice you choose, speech may be generated entirely on-device or by your browser/OS vendor’s voice services.
+    Read-Aloud itself does not receive your pasted text.
+    On the homepage, we also load an optional offline fallback voice engine (meSpeak).
+  </p>
+  <p>
+    <strong>We do not transmit the text you paste or type into the tool to our servers.</strong>
+    Your text stays in the page, and speech is generated through your browser/OS speech engine.
+  </p>
+
+  <h2>3) Information we collect</h2>
+  <div class="box">
+    <p style="margin-top:0"><strong>Information you provide</strong></p>
+    <ul>
+      <li>
+        <strong>Support messages:</strong> if you email us or use the contact form, we receive the information you send (such as your name, email address, and message) so we can reply.
+      </li>
+    </ul>
+
+    <p><strong>Information collected automatically</strong></p>
+    <ul>
+      <li>
+        <strong>Basic server logs:</strong> like most websites, our hosting provider may process standard logs (requested page, date/time, and basic device/network information) for security and reliability.
+      </li>
+      <li>
+        <strong>Homepage visit counter request:</strong> the homepage sends a request to a third-party counter service (CountAPI) to increment a public visit count. As with any web request, the provider may receive standard request data (such as IP address and user agent).
+      </li>
+      <li>
+        <strong>CDN requests for voice fallback:</strong> the homepage loads meSpeak files from a third-party CDN (jsDelivr). The CDN may receive standard request data (such as IP address and user agent).
+      </li>
+    </ul>
+
+    <p style="margin-bottom:0">
+      <strong>We do not create user profiles or store your pasted text in a database.</strong>
+    </p>
+  </div>
+
+  <h2>4) Cookies, local storage, and your consent choice</h2>
+  <p>
+    Read-Aloud itself is designed to work without requiring cookies for the core text-to-speech tool.
+    However, some third-party services (like advertising and analytics) may use cookies or similar technologies if enabled.
+  </p>
+
+  <div class="box">
+    <p style="margin-top:0"><strong>How our consent banner works</strong></p>
+    <ul>
+      <li>
+        We store your choice in <strong>localStorage</strong> under the key <code>ra_cookie_consent</code> with a value of <code>accepted</code> or <code>rejected</code>.
+      </li>
+      <li>
+        If you <strong>accept</strong>, we load Google Analytics and (on pages with an ad slot) Google AdSense.
+      </li>
+      <li>
+        If you <strong>reject</strong>, we do not load Google Analytics or Google AdSense.
+      </li>
+      <li>
+        <strong>Note:</strong> the homepage visit counter (CountAPI) and the meSpeak CDN files (jsDelivr) load regardless of this choice.
+      </li>
+    </ul>
+  </div>
+
+  <h2>5) Third-party services we use</h2>
+
+  <h3>Google Analytics (only after you accept)</h3>
+  <p>
+    If you accept the cookie banner, we use Google Analytics to understand basic site usage (for example, which pages are visited most).
+    We do not intentionally send the text you paste into the tool to Google Analytics.
+  </p>
+
+  <h3>Google AdSense advertising (only after you accept, and only where an ad slot appears)</h3>
   <div class="box">
     <p style="margin-top:0">
-      Read‑Aloud is designed to collect as little data as possible. In general:
-    </p>
-    <ul>
-      <li><strong>No user accounts:</strong> we do not ask you to sign in.</li>
-      <li><strong>No stored content:</strong> we do not store your pasted text in a database.</li>
-      <li><strong>Support messages:</strong> if you email us or use the contact form, we receive the information you send (like your email address and message) so we can respond.</li>
-    </ul>
-    <p class="small" style="margin-bottom:0">
-      Like most websites, our hosting provider may process standard server logs (e.g., requested page, date/time, and basic device/network information) for security and reliability.
-    </p>
-  </div>
-
-  <h2>3) Cookies, local storage, and third‑party services</h2>
-  <p>
-    Read‑Aloud itself aims to work without requiring cookies. However, third‑party services can use cookies or similar technologies
-    when you interact with them.
-  </p>
-
-  <h3>Donations (Buy Me a Coffee)</h3>
-  <p>
-    The site links to a donation page (Buy Me a Coffee). If you choose to donate, that service will process the transaction and may collect information
-    according to its own policies.
-  </p>
-
-    <h3>Promotional links</h3>
-    <p>
-      We do not currently include paid referral links or outbound product promotions while we focus on AdSense approval.
-      If we add promotional links in the future, we will disclose them on the relevant pages and note that the third‑party site’s
-      privacy policy applies after you click.
-    </p>
-
-  <h2>4) Advertising</h2>
-  <div class="box">
-    <p style="margin-top:0">
-      Read‑Aloud uses Google AdSense to serve ads on pages where ad slots appear.
-      Ads only load after you accept the cookie banner.
+      If you accept the cookie banner, we load Google AdSense on pages that display an ad slot (currently the homepage).
+      Google and its partners may use cookies or similar identifiers to serve ads, including (where permitted) personalized ads.
     </p>
     <p>
-      Google and its partners may use cookies or local storage to serve ads, including personalized ads where permitted by your settings and region.
+      In practice, this means:
     </p>
-    <p class="small" style="margin-bottom:0">
-      You can manage ad personalization via Google’s Ads Settings:
-      <a href="https://adssettings.google.com/" target="_blank" rel="noopener">adssettings.google.com</a>
-      (Google policies:
-      <a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener">policies.google.com/technologies/ads</a>).
-    </p>
-  </div>
-
-  <h2>5) Analytics</h2>
-  <p>
-    We use Google Analytics to understand basic site usage (for example, page popularity and overall traffic).
-    Analytics only load after you accept the cookie banner, and we avoid collecting sensitive personal data.
-  </p>
-  <div class="box">
-    <p style="margin-top:0"><strong>What you can expect from analytics:</strong></p>
     <ul>
-      <li>We collect aggregated usage metrics (e.g., pageviews, referrers, device type).</li>
-      <li>We do not collect your pasted text (the core tool text stays in your browser).</li>
-      <li>We only load analytics after you explicitly accept the cookie banner.</li>
+      <li>Third-party vendors (including Google) may use cookies/identifiers to show ads based on prior visits and activity.</li>
+      <li>Google’s advertising cookies allow Google and its partners to show ads based on visits to this site and/or other sites.</li>
     </ul>
     <p class="small" style="margin-bottom:0">
-      If you want us to use (or avoid) a particular analytics approach, you can email us and we’ll consider it.
+      You can manage ad personalization through Google’s Ads Settings:
+      <a href="https://adssettings.google.com/" target="_blank" rel="noopener">adssettings.google.com</a>.
+      More about Google ad technology:
+      <a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener">policies.google.com/technologies/ads</a>.
     </p>
   </div>
 
-  <h2>6) Your choices</h2>
+  <h3>Contact form (Formspree)</h3>
+  <p>
+    If you use our contact form, your message is submitted to a third-party form processor (Formspree) so it can be delivered to us.
+    Form submissions may include your name, email address, and message content.
+    Formspree’s processing is governed by their own privacy policy.
+  </p>
+
+  <h3>Visit counter (CountAPI)</h3>
+  <p>
+    The homepage calls a third-party counter endpoint to increment and display a public “visits” number.
+    This call may expose standard request data (like IP address and user agent) to that provider.
+  </p>
+
+  <h3>Voice fallback files (jsDelivr + meSpeak)</h3>
+  <p>
+    The homepage loads meSpeak JavaScript and voice configuration files from jsDelivr (a third-party CDN).
+    This improves reliability and provides an optional fallback voice engine, and the CDN may receive standard request data.
+  </p>
+
+  <h3>Donations (Buy Me a Coffee link)</h3>
+  <p>
+    We link to a donation page (Buy Me a Coffee). If you click that link and choose to donate,
+    that service will process the transaction and handle your information under its own policies.
+  </p>
+
+  <h2>6) How long we keep information</h2>
+  <p>
+    We keep support emails/contact form messages only as long as needed to respond and for reasonable record-keeping.
+    Hosting/third-party providers may retain logs according to their own retention practices.
+  </p>
+
+  <h2>7) Your choices</h2>
   <ul>
-    <li><strong>Don’t paste sensitive text</strong> on shared devices or while screen‑sharing.</li>
-    <li>You can use Google’s ad personalization controls (linked above).</li>
-    <li>You can choose not to click promotional links or external links.</li>
+    <li><strong>Cookie banner choice:</strong> you can accept or reject analytics/ads.</li>
+    <li><strong>Reset consent:</strong> use the button below to clear your saved choice and show the banner again.</li>
+    <li><strong>Ad personalization:</strong> use Google’s controls at adssettings.google.com.</li>
+    <li><strong>Shared devices:</strong> avoid pasting sensitive text on shared computers or while screen-sharing.</li>
+    <li><strong>Browser controls:</strong> you can also use browser settings, content blockers, or private browsing.</li>
   </ul>
 
   <h2>Cookie preferences</h2>
   <div class="box">
     <p style="margin-top:0">
-      You can change your analytics and ads choice at any time. Selecting reset will show the consent banner again.
+      Selecting reset will remove your stored choice (<code>ra_cookie_consent</code>) and show the consent banner again.
     </p>
     <button type="button" class="btn secondary" data-cookie-reset>Reset cookie preferences</button>
   </div>
 
-  <h2>7) Contact</h2>
+  <h2>8) Children</h2>
   <p>
-    If you have privacy questions, email <strong>admin@read-aloud.com</strong> or use the
-    <a href="/contact.html">contact form</a>.
+    Read-Aloud is intended for a general audience and is not directed to children under 13.
+    If you believe a child has provided personal information via our contact form, please email us and we will address it.
   </p>
 
-  <h2>8) Changes</h2>
+  <h2>9) International visitors</h2>
   <p>
-    If we change this policy, we’ll update the “Last updated” date above. Changes take effect when posted on this page.
+    If you enable ads/analytics, those providers may process data on servers located in different countries.
+    Requirements vary by region; where consent is required for ads/analytics, you can reject via the banner.
+  </p>
+
+  <h2>10) Changes</h2>
+  <p>
+    If we update this policy, we’ll change the “Last updated” date above. Changes take effect when posted.
   </p>
 
   <hr>
   <p class="small">
-    Related: <a href="/terms.html">Terms</a> · <a href="about.html">About</a> · <a href="guides.html">Guides</a>
+    Related: <a href="/terms.html">Terms</a> · <a href="/about.html">About</a> · <a href="/guides.html">Guides</a>
   </p>
 
   <p class="small">
-    © 2026 Read‑Aloud · <a href="/contact.html">Contact</a> · <a href="/terms.html">Terms</a>
+    © 2026 Read-Aloud · <a href="/contact.html">Contact</a> · <a href="/terms.html">Terms</a>
   </p>
 </main>
 

--- a/terms.html
+++ b/terms.html
@@ -141,7 +141,7 @@
 
   <hr>
   <p class="small">
-    Related: <a href="/privacy.html">Privacy Policy</a> · <a href="about.html">About</a> · <a href="help.html">Help</a>
+    Related: <a href="/privacy.html">Privacy Policy</a> · <a href="/about.html">About</a> · <a href="/help.html">Help</a>
   </p>
 </main>
 


### PR DESCRIPTION
### Motivation
- Make the privacy policy wording defensible and aligned with the site’s actual behavior around speech generation and third‑party services.
- Ensure internal navigation and “Related / Next / All Guides” links are consistent across guide and info pages.

### Description
- Updated `privacy.html` to soften the claim that text is spoken “locally” by stating text is spoken by the browser/operating system’s speech engine (via the Web Speech API), added explanatory paragraphs about voice behavior, reorganized section headings, and updated the “Last updated” date to `January 18, 2026`.
- Documented consent and third‑party behavior in `privacy.html`, including how we store the consent choice in `localStorage` under the key `ra_cookie_consent`, the cookie reset button (`data-cookie-reset`), that Google Analytics and Google AdSense only load after consent, and that the homepage always calls CountAPI and loads meSpeak files from jsDelivr; also added notes on Formspree, donations, retention, children, and international visitors.
- Normalized internal links across multiple files (`about.html`, `terms.html`, `guide-*.html`, `guide-privacy.html`, `guide-how-to-use.html`, `guide-study.html`, `guide-proofread.html`, etc.) by changing relative links like `help.html` and `guides.html` to absolute paths (`/help.html`, `/guides.html`) for consistent navigation.

### Testing
- Served the site locally with `python -m http.server 8000` and captured a full-page screenshot of `/privacy.html` using a Playwright script, which completed successfully (artifact saved).
- Performed a commit that recorded the changes (commit message: "Normalize guide links and refine privacy wording") and verified the modified files in `git status` (10 files changed).
- No automated unit tests were applicable for these static content and link normalization updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ce8f548c8833190919d01a67d5a3a)