### PR TITLE
Fix speech stopping mid-playback and text display overrun

### DIFF
--- a/readaloud.js
+++ b/readaloud.js
@@ -79,6 +79,7 @@ let isPaused = false;
 let useNeuralTTS = true; // Prefer neural voices
 let apiAvailable = false;
 let downloadBlobs = []; // Collect MP3 chunks for download
+let keepAliveTimer = null; // Chrome speech synthesis keep-alive
 
 /* ========== INIT ========== */
 (async function init() {
@@ -447,8 +448,28 @@ function useBrowserSpeech(voiceIndex) {
   isPaused = false;
   setStatus('Playing...');
   updateControls();
+  startKeepAlive();
   speakNextChunk(voiceIndex);
   requestAnimationFrame(progressLoop);
+}
+
+// Chrome kills speechSynthesis after ~15s of continuous speech.
+// Periodically pause/resume to keep it alive.
+function startKeepAlive() {
+  stopKeepAlive();
+  keepAliveTimer = setInterval(() => {
+    if (isSpeaking && !isPaused && speechSynthesis.speaking) {
+      speechSynthesis.pause();
+      speechSynthesis.resume();
+    }
+  }, 10000);
+}
+
+function stopKeepAlive() {
+  if (keepAliveTimer) {
+    clearInterval(keepAliveTimer);
+    keepAliveTimer = null;
+  }
 }
 
 function speakNextChunk(voiceIndex) {
@@ -580,6 +601,7 @@ function stopAll() {
 
   // Stop browser speech
   speechSynthesis.cancel();
+  stopKeepAlive();
 
   queue = [];
   isSpeaking = false;
@@ -595,6 +617,7 @@ function finish() {
   isSpeaking = false;
   isPaused = false;
   currentAudio = null;
+  stopKeepAlive();
   updateMeter(totalChars);
   setStatus('Finished');
   updateControls();
@@ -623,7 +646,8 @@ function resetMeter() {
 
 function autoSize() {
   txt.style.height = 'auto';
-  txt.style.height = txt.scrollHeight + 'px';
+  const maxH = window.innerHeight * 0.45; // match CSS max-height: 45vh
+  txt.style.height = Math.min(txt.scrollHeight, maxH) + 'px';
 }
 
 /* ========== UI HELPERS ========== */

--- a/styles.css
+++ b/styles.css
@@ -655,6 +655,13 @@ textarea#txt {
   resize: vertical;
 }
 
+#disp {
+  max-height: 30vh;
+  overflow-y: auto;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
 progress {
   width: 100%;
   height: 12px;


### PR DESCRIPTION
- Add Chrome speechSynthesis keep-alive timer that periodically pause/resumes to prevent the ~15s cutoff bug
- Constrain #disp div with max-height and overflow-y to prevent text from overflowing the panel when long text is pasted
- Cap autoSize() to respect the 45vh max-height on the textarea

https://claude.ai/code/session_01N9HekcdXY7Qha3ub7PdsZ5